### PR TITLE
Add automotive to the crates categories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/ankaios-sdk/0.6.0"
 repository = "https://github.com/eclipse-ankaios/ank-sdk-rust"
 readme = "README.md"
 keywords = ["ankaios", "automotive", "sdk", "container", "orchestration"]
-categories = ["virtualization", "api-bindings"]  # https://crates.io/category_slugs
+categories = ["automotive", "virtualization", "api-bindings"]  # https://crates.io/category_slugs
 exclude = ["/tests", "/.github"]
 
 [lib]


### PR DESCRIPTION
As there is a new category called `automotive`, the Rust SDK should be part of it.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-contribute) have been handled
