### PR TITLE
Bump rust-cache action to v2.9.1

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
     - name: Install deps
       run: sudo apt -y install protobuf-compiler


### PR DESCRIPTION
# Description

There are some warnings about `Node.js 20 actions are deprecated` within the Swatinem/rust-cache action.
This PR pumps-up the action to the latest version (2.9.1) which fixes this issue.

The warnings can be seen here: https://github.com/eclipse-ankaios/ank-sdk-rust/actions/runs/23045132086

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-contribute) have been handled
