### PR TITLE
Fix clippy warnings generated by rust 1.97

### DIFF
--- a/src/ankaios.rs
+++ b/src/ankaios.rs
@@ -1617,7 +1617,7 @@ mod tests {
 
         // Get the result
         let ret = method_handle.await.unwrap().unwrap();
-        assert!(ret.added_workloads.len() == 1);
+        assert_eq!(ret.added_workloads.len(), 1);
         assert!(ret.deleted_workloads.is_empty());
     }
 
@@ -1770,7 +1770,7 @@ mod tests {
 
         // Get the result
         let ret = method_handle.await.unwrap().unwrap();
-        assert!(ret.added_workloads.len() == 1);
+        assert_eq!(ret.added_workloads.len(), 1);
         assert!(ret.deleted_workloads.is_empty());
     }
 
@@ -1923,7 +1923,7 @@ mod tests {
 
         // Get the result
         let ret = method_handle.await.unwrap().unwrap();
-        assert!(ret.added_workloads.len() == 1);
+        assert_eq!(ret.added_workloads.len(), 1);
         assert!(ret.deleted_workloads.is_empty());
     }
 
@@ -2069,7 +2069,7 @@ mod tests {
         response_sender.send(response).await.unwrap();
 
         let ret = method_handle.await.unwrap().unwrap();
-        assert!(ret.added_workloads.len() == 1);
+        assert_eq!(ret.added_workloads.len(), 1);
         assert!(ret.deleted_workloads.is_empty());
     }
 
@@ -2167,7 +2167,7 @@ mod tests {
 
         // Get the result
         let ret = method_handle.await.unwrap().unwrap();
-        assert!(ret.added_workloads.len() == 1);
+        assert_eq!(ret.added_workloads.len(), 1);
         assert!(ret.deleted_workloads.is_empty());
     }
 
@@ -2313,7 +2313,7 @@ mod tests {
 
         // Get the result
         let ret = method_handle.await.unwrap().unwrap();
-        assert!(ret.added_workloads.len() == 1);
+        assert_eq!(ret.added_workloads.len(), 1);
         assert!(ret.deleted_workloads.is_empty());
     }
 
@@ -2464,7 +2464,7 @@ mod tests {
 
         // Get the result
         let ret = method_handle.await.unwrap().unwrap();
-        assert!(ret.added_workloads.len() == 1);
+        assert_eq!(ret.added_workloads.len(), 1);
         assert!(ret.deleted_workloads.is_empty());
     }
 


### PR DESCRIPTION
# Description

Some clippy warnings were found by the latest rust 1.97. This PR fixes them.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-contribute) have been handled
