### PR TITLE
Add GRPC connection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,7 @@
         "substate",
         "thiserror",
         "unistd",
+        "unregisters",
         "utest",
         "varint",
         "withf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,5 +54,6 @@ test_utils = []
 # Enables connecting to Ankaios from inside a workload via the control interface (named pipes).
 control_interface = []
 # Enables connecting to an Ankaios server directly over gRPC (e.g. from outside a workload).
-# Independent of `control_interface`; both may be enabled at once.
+# Independent of `control_interface`; although enabling both at once works, it makes sense to
+# only use the one fitting the use case.
 grpc_server_interface = ["dep:tonic-prost", "dep:tokio-stream", "tonic/tls-ring"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ default = ["control_interface"]
 test_utils = []
 # Enables connecting to Ankaios from inside a workload via the control interface (named pipes).
 control_interface = []
-# Enables connecting to an Ankaios server directly over gRPC (e.g. from outside a workload).
-# Independent of `control_interface`; although enabling both at once works, it makes sense to
-# only use the one fitting the use case.
-grpc_server_interface = ["dep:tonic-prost", "dep:tokio-stream", "tonic/tls-ring"]
+# Enables connection to Ankaios from outside a workload via the command interface,
+# which represent a direct gRPC connection to the Ankaios server
+command_interface = ["dep:tonic-prost", "dep:tokio-stream", "tonic/tls-ring"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ crate-type = ["lib"]
 [dependencies]
 prost = "0.14"
 tonic = "0.14"
+tonic-prost = { version = "0.14", optional = true }
+tokio-stream = { version = "0.1", optional = true }
 log = "0.4"
 env_logger = "0.11"
 serde = { version = "1.0", features = ["derive"] }
@@ -42,11 +44,15 @@ home = "=0.5.9"
 tempfile = "3.4"
 nix = { version = "0.30", features = ["fs", "user"] }
 mockall = "0.14"
-mockall_double = "0.3"
 
 [build-dependencies]
 tonic-prost-build = "0.14"
 
 [features]
-default = []
+default = ["control_interface"]
 test_utils = []
+# Enables connecting to Ankaios from inside a workload via the control interface (named pipes).
+control_interface = []
+# Enables connecting to an Ankaios server directly over gRPC (e.g. from outside a workload).
+# Independent of `control_interface`; both may be enabled at once.
+grpc_server_interface = ["dep:tonic-prost", "dep:tokio-stream", "tonic/tls-ring"]

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ use tokio::time::Duration;
 async fn main() {
     // Create a new Ankaios object.
     // The connection to the control interface is automatically done at this step.
-    let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
+    let mut ank = Ankaios::builder().control_interface().connect().await.expect("Failed to initialize");
 
     // Create a new workload
     let workload = Workload::builder()

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ use tokio::time::Duration;
 async fn main() {
     // Create a new Ankaios object.
     // The connection to the control interface is automatically done at this step.
-    let mut ank = Ankaios::new().await.expect("Failed to initialize");
+    let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
 
     // Create a new workload
     let workload = Workload::builder()

--- a/README.md
+++ b/README.md
@@ -145,20 +145,21 @@ To connect to an Ankaios server directly from outside a workload (e.g. from
 a CI job or a management tool), use the command interface instead, which relies on
 a gRPC connection directly to the Ankaios agent:
 
-```rust
+```rust,no_run
 use ankaios_sdk::{Ankaios, GrpcConfig};
 use tokio::time::Duration;
 
 #[tokio::main]
 async fn main() {
     // Setup the gRPC connection
+    let server_url = "http://127.0.0.1:25551";
     let grpc_config = GrpcConfig::insecure(server_url); // or GrpcConfig::mtls
-    // Create a new Ankaios object.
 
+    // Create a new Ankaios object.
     // The connection to the command interface is automatically done at this step.
     let mut ank = Ankaios::builder().command_interface(grpc_config).connect().await.expect("Failed to initialize");
 
-    ...
+    // From here on, the API is identical to the control interface example above.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ are using. For information regarding versioning, please refer to this table:
 After setup, you can use the Ankaios SDK to configure and run workloads
 and request the state of the Ankaios system and the connected agents.
 
+### Connecting over The Control Interface
+
 The following example assumes that the code is running in a workload managed by
 Ankaios with configured control interface access. This can also be tested from the
 [examples](examples) by running `./run_example.sh hello_ankaios`.
@@ -136,6 +138,43 @@ async fn main() {
     }
 }
 ```
+
+### Connecting over The Command Interface
+
+To connect to an Ankaios server directly from outside a workload (e.g. from
+a CI job or a management tool), use the command interface instead, which relies on
+a gRPC connection directly to the Ankaios agent:
+
+```rust
+use ankaios_sdk::{Ankaios, GrpcConfig};
+use tokio::time::Duration;
+
+#[tokio::main]
+async fn main() {
+    // Setup the gRPC connection
+    let grpc_config = GrpcConfig::insecure(server_url); // or GrpcConfig::mtls
+    // Create a new Ankaios object.
+
+    // The connection to the command interface is automatically done at this step.
+    let mut ank = Ankaios::builder().command_interface(grpc_config).connect().await.expect("Failed to initialize");
+
+    ...
+}
+```
+
+This requires the command interface feature to be enabled:
+
+```toml
+ankaios_sdk = { ..., default-features = false, features = ["command_interface"] }
+```
+
+> **_NOTE:_**  The default feature is the control interface. Without disabling it,
+> both features will be available.
+
+For mTLS-secured connections, also pass `ca_pem`, `crt_pem` and `key_pem`
+(the PEM-encoded CA certificate, client certificate and client key content).
+
+### Resources
 
 For more details, please visit:
 

--- a/build.rs
+++ b/build.rs
@@ -30,7 +30,7 @@ fn main() {
             .unwrap();
     }
 
-    if std::env::var("CARGO_FEATURE_GRPC_SERVER_INTERFACE").is_ok() {
+    if std::env::var("CARGO_FEATURE_COMMAND_INTERFACE").is_ok() {
         // Client-only: this SDK never needs to run a CliConnection/AgentConnection server.
         let mut grpc_builder = tonic_prost_build::configure().build_server(false);
         grpc_builder = setup_proto_annotations(grpc_builder);

--- a/build.rs
+++ b/build.rs
@@ -17,14 +17,26 @@ mod build;
 use build::setup_proto_annotations;
 
 fn main() {
-    let mut builder = tonic_prost_build::configure()
-        .build_server(true)
-        .type_attribute("WorkloadState", "#[allow(dead_code)]"); // Workaround until the release of the ankaios api
+    if std::env::var("CARGO_FEATURE_CONTROL_INTERFACE").is_ok() {
+        let mut builder = tonic_prost_build::configure()
+            .build_server(true)
+            .type_attribute("WorkloadState", "#[allow(dead_code)]"); // Workaround until the release of the ankaios api
 
-    // Setup the proto objects
-    builder = setup_proto_annotations(builder);
+        // Setup the proto objects
+        builder = setup_proto_annotations(builder);
 
-    builder
-        .compile_protos(&["proto/control_api.proto"], &["proto"])
-        .unwrap();
+        builder
+            .compile_protos(&["proto/control_api.proto"], &["proto"])
+            .unwrap();
+    }
+
+    if std::env::var("CARGO_FEATURE_GRPC_SERVER_INTERFACE").is_ok() {
+        // Client-only: this SDK never needs to run a CliConnection/AgentConnection server.
+        let mut grpc_builder = tonic_prost_build::configure().build_server(false);
+        grpc_builder = setup_proto_annotations(grpc_builder);
+
+        grpc_builder
+            .compile_protos(&["proto/grpc_api.proto"], &["proto"])
+            .unwrap();
+    }
 }

--- a/examples/apps/get_logs.rs
+++ b/examples/apps/get_logs.rs
@@ -22,7 +22,7 @@ async fn main() {
 
     // Create a new Ankaios object.
     // The connection to the control interface is automatically done at this step.
-    let mut ank = Ankaios::new().await.expect("Failed to initialize");
+    let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
 
     // Create a new workload outputting test logs.
     let workload = Workload::builder()

--- a/examples/apps/get_logs.rs
+++ b/examples/apps/get_logs.rs
@@ -22,7 +22,7 @@ async fn main() {
 
     // Create a new Ankaios object.
     // The connection to the control interface is automatically done at this step.
-    let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
+    let mut ank = Ankaios::builder().control_interface().connect().await.expect("Failed to initialize");
 
     // Create a new workload outputting test logs.
     let workload = Workload::builder()

--- a/examples/apps/get_state.rs
+++ b/examples/apps/get_state.rs
@@ -41,7 +41,7 @@ async fn main() {
 
     // Create a new Ankaios object.
     // The connection to the control interface is automatically done at this step.
-    let mut ank = Ankaios::new().await.expect("Failed to initialize");
+    let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
 
     // Create a new workload
     let workload = Workload::builder()

--- a/examples/apps/get_state.rs
+++ b/examples/apps/get_state.rs
@@ -41,7 +41,7 @@ async fn main() {
 
     // Create a new Ankaios object.
     // The connection to the control interface is automatically done at this step.
-    let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
+    let mut ank = Ankaios::builder().control_interface().connect().await.expect("Failed to initialize");
 
     // Create a new workload
     let workload = Workload::builder()

--- a/examples/apps/hello_ankaios.rs
+++ b/examples/apps/hello_ankaios.rs
@@ -23,7 +23,7 @@ async fn main() {
 
     // Create a new Ankaios object.
     // The connection to the control interface is automatically done at this step.
-    let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
+    let mut ank = Ankaios::builder().control_interface().connect().await.expect("Failed to initialize");
 
     // Create a new workload
     let workload = Workload::builder()

--- a/examples/apps/hello_ankaios.rs
+++ b/examples/apps/hello_ankaios.rs
@@ -23,7 +23,7 @@ async fn main() {
 
     // Create a new Ankaios object.
     // The connection to the control interface is automatically done at this step.
-    let mut ank = Ankaios::new().await.expect("Failed to initialize");
+    let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
 
     // Create a new workload
     let workload = Workload::builder()

--- a/examples/apps/simple_test.rs
+++ b/examples/apps/simple_test.rs
@@ -23,14 +23,14 @@ async fn main() {
 
     {
         println!("Ankaios 1");
-        let mut _ank = Ankaios::new().await.expect("Failed to initialize");
+        let mut _ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
         sleep(Duration::from_secs(5)).await;
     }
     println!("Pause");
     sleep(Duration::from_secs(5)).await;
     {
         println!("Ankaios 2");
-        let mut _ank = Ankaios::new().await.expect("Failed to initialize");
+        let mut _ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
         sleep(Duration::from_secs(5)).await;
     }
     println!("End");

--- a/examples/apps/simple_test.rs
+++ b/examples/apps/simple_test.rs
@@ -23,14 +23,14 @@ async fn main() {
 
     {
         println!("Ankaios 1");
-        let mut _ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
+        let mut _ank = Ankaios::builder().control_interface().connect().await.expect("Failed to initialize");
         sleep(Duration::from_secs(5)).await;
     }
     println!("Pause");
     sleep(Duration::from_secs(5)).await;
     {
         println!("Ankaios 2");
-        let mut _ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
+        let mut _ank = Ankaios::builder().control_interface().connect().await.expect("Failed to initialize");
         sleep(Duration::from_secs(5)).await;
     }
     println!("End");

--- a/examples/apps/state_event.rs
+++ b/examples/apps/state_event.rs
@@ -22,7 +22,7 @@ async fn main() {
 
     // Create a new Ankaios object.
     // The connection to the control interface is automatically done at this step.
-    let mut ank = Ankaios::new().await.expect("Failed to initialize");
+    let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
 
     // Create a new workload outputting test logs.
     let workload = Workload::builder()

--- a/examples/apps/state_event.rs
+++ b/examples/apps/state_event.rs
@@ -22,7 +22,7 @@ async fn main() {
 
     // Create a new Ankaios object.
     // The connection to the control interface is automatically done at this step.
-    let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
+    let mut ank = Ankaios::builder().control_interface().connect().await.expect("Failed to initialize");
 
     // Create a new workload outputting test logs.
     let workload = Workload::builder()

--- a/examples/apps/test_configs.rs
+++ b/examples/apps/test_configs.rs
@@ -41,7 +41,7 @@ async fn main() {
 
     // Create a new Ankaios object.
     // The connection to the control interface is automatically done at this step.
-    let mut ank = Ankaios::new().await.expect("Failed to initialize");
+    let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
 
     // Create a new workload
     let workload = Workload::builder()

--- a/examples/apps/test_configs.rs
+++ b/examples/apps/test_configs.rs
@@ -41,7 +41,7 @@ async fn main() {
 
     // Create a new Ankaios object.
     // The connection to the control interface is automatically done at this step.
-    let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
+    let mut ank = Ankaios::builder().control_interface().connect().await.expect("Failed to initialize");
 
     // Create a new workload
     let workload = Workload::builder()

--- a/examples/apps/test_files.rs
+++ b/examples/apps/test_files.rs
@@ -38,7 +38,7 @@ async fn main() {
     // The connection to the control interface is automatically done at this step.
     println!("PLEASE PROVIDE VALID FILES' PATHS IF YOU WANT TO FULLY USE THIS EXAMPLE");
 
-    let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
+    let mut ank = Ankaios::builder().control_interface().connect().await.expect("Failed to initialize");
 
     // Create a workload with text file
     let workload_with_text_file = Workload::builder()

--- a/examples/apps/test_files.rs
+++ b/examples/apps/test_files.rs
@@ -38,7 +38,7 @@ async fn main() {
     // The connection to the control interface is automatically done at this step.
     println!("PLEASE PROVIDE VALID FILES' PATHS IF YOU WANT TO FULLY USE THIS EXAMPLE");
 
-    let mut ank = Ankaios::new().await.expect("Failed to initialize");
+    let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
 
     // Create a workload with text file
     let workload_with_text_file = Workload::builder()

--- a/examples/apps/test_manifest.rs
+++ b/examples/apps/test_manifest.rs
@@ -41,7 +41,7 @@ async fn main() {
 
     // Create a new Ankaios object.
     // The connection to the control interface is automatically done at this step.
-    let mut ank = Ankaios::new().await.expect("Failed to initialize");
+    let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
 
     // Create manifest
     let manifest_str = r#"apiVersion: v1

--- a/examples/apps/test_manifest.rs
+++ b/examples/apps/test_manifest.rs
@@ -41,7 +41,7 @@ async fn main() {
 
     // Create a new Ankaios object.
     // The connection to the control interface is automatically done at this step.
-    let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
+    let mut ank = Ankaios::builder().control_interface().connect().await.expect("Failed to initialize");
 
     // Create manifest
     let manifest_str = r#"apiVersion: v1

--- a/examples/apps/test_workload.rs
+++ b/examples/apps/test_workload.rs
@@ -41,7 +41,7 @@ async fn main() {
 
     // Create a new Ankaios object.
     // The connection to the control interface is automatically done at this step.
-    let mut ank = Ankaios::new().await.expect("Failed to initialize");
+    let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
 
     // Create a new workload
     let workload = Workload::builder()

--- a/examples/apps/test_workload.rs
+++ b/examples/apps/test_workload.rs
@@ -41,7 +41,7 @@ async fn main() {
 
     // Create a new Ankaios object.
     // The connection to the control interface is automatically done at this step.
-    let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
+    let mut ank = Ankaios::builder().control_interface().connect().await.expect("Failed to initialize");
 
     // Create a new workload
     let workload = Workload::builder()

--- a/justfile
+++ b/justfile
@@ -2,11 +2,11 @@
 
 # Build SDK
 build:
-    cargo build
+    cargo build --all-features
 
 # Build SDK in release mode
 build-release:
-    cargo build --release
+    cargo build --release --all-features
 
 # Clean the build directory
 clean:
@@ -22,15 +22,15 @@ all-tests: test doctest
 
 # Run tests using cargo nextest if installed
 test:
-    bash -c 'if which cargo-nextest > /dev/null 2>&1; then cargo nextest run; else cargo test --tests; fi'
+    bash -c 'if which cargo-nextest > /dev/null 2>&1; then cargo nextest run --all-features; else cargo test --tests --all-features; fi'
 
 # Run documentation tests
 doctest:
-    cargo test --doc --target x86_64-unknown-linux-gnu
+    cargo test --doc --target x86_64-unknown-linux-gnu --all-features
 
 # Run code coverage
 cov:
-    cargo llvm-cov
+    cargo llvm-cov --all-features
 
 # Check coverage
 cov-check:
@@ -38,7 +38,7 @@ cov-check:
 
 # Generate code coverage HTML
 cov-html:
-    cargo llvm-cov --html
+    cargo llvm-cov --all-features --html
 
 # Open code coverage HTML
 cov-open:
@@ -59,4 +59,4 @@ deny:
 # Find the minimum supported Rust version (MSRV)
 msrv-find:
     bash -c 'if ! which cargo-msrv > /dev/null 2>&1; then cargo install cargo-msrv; fi'
-    cargo msrv find --include-all-patch-releases --linear # --output-format minimal
+    cargo msrv find --include-all-patch-releases --linear -- cargo check --all-features # --output-format minimal

--- a/proto/grpc_api.proto
+++ b/proto/grpc_api.proto
@@ -35,8 +35,24 @@ service AgentConnection {
     rpc ConnectAgent (stream ToServer) returns (stream FromServer);
 }
 
+/**
+* Deprecated: use the CommandConnection service instead.
+*
+* This service is kept only for backwards compatibility. Clients connected via
+* this service are stored in the same senders map as the Ankaios agents and
+* therefore receive messages targeted at agents (e.g. unsolicited
+* UpdateWorkloadState and LogsCancelRequest messages). New commander
+* applications shall connect via the CommandConnection service.
+*/
 service CliConnection {
-    rpc ConnectCli (stream ToServer) returns (stream FromServer);
+    option deprecated = true;
+    rpc ConnectCli (stream ToServer) returns (stream FromServer) {
+        option deprecated = true;
+    }
+}
+
+service CommandConnection {
+    rpc ConnectCommand (stream ToServer) returns (stream FromServer);
 }
 
 /**

--- a/proto/grpc_api.proto
+++ b/proto/grpc_api.proto
@@ -1,0 +1,168 @@
+// Copyright (c) 2023 Elektrobit Automotive GmbH
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+* The Ankaios communication protocol is used in the communication between the following components:
+*
+* 1. Ankaios Agent and Ankaios Server,
+*
+* 2. Ankaios CLI and Ankaios Server,
+*
+* The protocol consists of the following top-level message types:
+*
+* 1. [ToServer](#toserver): agent/cli -> server
+*
+* 2. [FromServer](#fromserver): server -> agent/cli
+*
+*/
+syntax = "proto3";
+package grpc_api;
+
+import "ank_base.proto";
+
+service AgentConnection {
+    rpc ConnectAgent (stream ToServer) returns (stream FromServer);
+}
+
+service CliConnection {
+    rpc ConnectCli (stream ToServer) returns (stream FromServer);
+}
+
+/**
+* Messages to the Ankaios server.
+*/
+message ToServer {
+    oneof ToServerEnum {
+        AgentHello agentHello = 1; /// This is the first message sent by an Ankaios agent when it connects to the cluster.
+        UpdateWorkloadState updateWorkloadState = 2; /// A message to Ankaios server to update the execution state of a workload.
+        ank_base.Request request = 3;
+        Goodbye goodbye = 4;
+        AgentLoadStatus AgentLoadStatus = 5;
+        CommanderHello commanderHello = 6; /// This is the first message sent by the ank CLI or a third-party command component connected directly to the Ankaios server.
+        LogEntriesResponse logEntriesResponse = 7;
+        LogsStopResponse logsStopResponse = 8;
+    }
+}
+
+message LogEntriesResponse {
+    string requestId = 1;
+    ank_base.LogEntriesResponse logEntriesResponse = 2;
+}
+
+message LogsStopResponse {
+    string requestId = 1;
+    ank_base.LogsStopResponse logsStopResponse = 2;
+}
+
+/**
+* Messages from the Ankaios server to e.g. the Ankaios agent.
+*/
+message FromServer {
+    oneof FromServerEnum {
+        UpdateWorkload updateWorkload = 1; /// A message containing lists of workloads to be added or deleted.
+        UpdateWorkloadState updateWorkloadState = 2; /// A message containing list of workload execution states.
+        ank_base.Response response = 3; /// A message containing a response to a previous request.
+        ServerHello serverHello = 4; /// A message containing information about the workloads to be added after the agent connects.
+        LogsRequest logsRequest = 5;
+        LogsCancelRequest logsCancelRequest = 6;
+    }
+}
+
+message LogsRequest {
+    string requestId = 1;
+    ank_base.LogsRequest logsRequest = 2;
+}
+
+message LogsCancelRequest {
+    string requestId = 1;
+}
+
+/**
+* A message to the Ankaios server to register a new agent.
+*/
+message AgentHello {
+    string agentName = 1; /// A unique agent name.
+    string protocolVersion = 2; /// The protocol version used by the calling component.
+    ank_base.Tags tags = 3; /// A set of tags assigned to the agent.
+}
+
+/**
+* A message to the Ankaios server to provide basic node resource availability.
+*/
+message AgentLoadStatus {
+    string agent_name = 1; /// A unique agent name.
+    ank_base.CpuUsage cpu_usage = 2; /// The cpu usage of the agent.
+    ank_base.FreeMemory free_memory = 3; /// The amount of free memory of the agent.
+}
+
+/**
+* A message to the Ankaios server to register a new CLI session or a third-party command component.
+*/
+message CommanderHello {
+    string protocolVersion = 2; /// The protocol version used by the calling component.
+}
+
+/**
+* A message to the Ankaios server to signalize a client (agent or cli) is shutting down.
+*/
+message Goodbye {
+}
+
+/**
+* A message representing the response to the AgentHello message from agent. It provides information about the added workloads of the agent.
+*/
+message ServerHello {
+    repeated AddedWorkload addedWorkloads = 1; /// A list of messages containing information about a workload to be added by an Ankaios agent.
+}
+
+/**
+* A message providing information about the workloads to be added and/or deleted.
+*/
+message UpdateWorkload {
+    repeated AddedWorkload addedWorkloads = 1; /// A list of messages containing information about a workload to be added by an Ankaios agent.
+    repeated DeletedWorkload deletedWorkloads = 2; /// A list of messages containing information about a workload to be deleted by an Ankaios agent.
+}
+
+/**
+* A message containing information about a workload to be added to the Ankaios cluster.
+*/
+message AddedWorkload {
+    ank_base.WorkloadInstanceName instanceName = 1; /// The instance name of the workload.
+    ank_base.Workload workload = 2; /// The workload to be added.
+}
+
+/**
+* A message containing information about a workload to be deleted from the Ankaios system.
+*/
+message DeletedWorkload {
+    ank_base.WorkloadInstanceName instanceName = 1; /// The instance name of the workload.
+    map<string, DeleteCondition> dependencies = 2; /// A list of dependencies to other workloads with their corresponding, expected states. Can be used to enable a synchronized stop of a workload.
+}
+
+/**
+* An enum type describing the conditions for deleting a workload. Used for dependency management, and update strategies.
+*/
+enum DeleteCondition {
+    DEL_COND_RUNNING = 0; /// The workload is operational.
+    DEL_COND_NOT_PENDING_NOR_RUNNING = 1; /// The workload is not scheduled or running.
+}
+
+/**
+* A message containing the list the workload states.
+*/
+message UpdateWorkloadState {
+    repeated ank_base.WorkloadState workloadStates = 1; /// A list of workload states.
+}
+
+

--- a/src/ankaios.rs
+++ b/src/ankaios.rs
@@ -69,7 +69,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// #
 /// # Runtime::new().unwrap().block_on(async {
 ///
-/// let ankaios = Ankaios::new_with_ci().await.unwrap();
+/// let ankaios = Ankaios::builder().control_interface().connect().await.unwrap();
 /// /* */
 /// drop(ankaios);
 /// # })
@@ -84,7 +84,23 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// #
 /// # Runtime::new().unwrap().block_on(async {
 /// #
-/// let ankaios = Ankaios::new_with_ci_and_timeout(Duration::from_secs(5)).await.unwrap();
+/// let ankaios = Ankaios::builder().control_interface().timeout(Duration::from_secs(5)).connect().await.unwrap();
+/// # })
+/// ```
+///
+/// ## Create an Ankaios object, connect and disconnect from the grpc command interface:
+///
+/// ```rust,no_run
+/// use ankaios_sdk::{Ankaios, GrpcConfig};
+/// # use tokio::runtime::Runtime;
+/// #
+/// # Runtime::new().unwrap().block_on(async {
+///
+/// # let server_url = String::new();
+/// let grpc_config = GrpcConfig::new(server_url);
+/// let ankaios = Ankaios::builder().command_interface(grpc_config).connect().await.unwrap();
+/// /* */
+/// drop(ankaios);
 /// # })
 /// ```
 ///
@@ -95,7 +111,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use tokio::runtime::Runtime;
 /// #
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
+/// # let mut ankaios = Ankaios::builder().control_interface().connect().await.unwrap();
 /// #
 /// let manifest: Manifest;
 /// # let manifest = Manifest::from_string("").unwrap();
@@ -111,7 +127,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use tokio::runtime::Runtime;
 /// #
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
+/// # let mut ankaios = Ankaios::builder().control_interface().connect().await.unwrap();
 /// #
 /// let manifest: Manifest;
 /// # let manifest = Manifest::from_string("").unwrap();
@@ -127,7 +143,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use tokio::runtime::Runtime;
 /// #
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
+/// # let mut ankaios = Ankaios::builder().control_interface().connect().await.unwrap();
 /// #
 /// let workload: Workload;
 /// # let workload = Workload::builder().build().unwrap();
@@ -143,7 +159,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use tokio::runtime::Runtime;
 /// #
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
+/// # let mut ankaios = Ankaios::builder().control_interface().connect().await.unwrap();
 /// #
 /// let workload_name: String;
 /// # let workload_name = String::new();
@@ -158,7 +174,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use ankaios_sdk::Ankaios;
 /// # use tokio::runtime::Runtime;
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
+/// # let mut ankaios = Ankaios::builder().control_interface().connect().await.unwrap();
 /// #
 /// let workload_name: String;
 /// # let workload_name = String::new();
@@ -173,7 +189,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use ankaios_sdk::Ankaios;
 /// # use tokio::runtime::Runtime;
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
+/// # let mut ankaios = Ankaios::builder().control_interface().connect().await.unwrap();
 /// #
 /// let state = ankaios.get_state(Vec::default()).await.unwrap();
 /// println!("{:?}", state);
@@ -186,7 +202,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use ankaios_sdk::Ankaios;
 /// # use tokio::runtime::Runtime;
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
+/// # let mut ankaios = Ankaios::builder().control_interface().connect().await.unwrap();
 /// #
 /// let agents = ankaios.get_agents().await.unwrap();
 /// println!("{:?}", agents);
@@ -199,7 +215,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use ankaios_sdk::Ankaios;
 /// # use tokio::runtime::Runtime;
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
+/// # let mut ankaios = Ankaios::builder().control_interface().connect().await.unwrap();
 /// #
 /// let workload_states_collection = ankaios.get_workload_states().await.unwrap();
 /// let workload_states = workload_states_collection.as_list();
@@ -212,7 +228,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use ankaios_sdk::Ankaios;
 /// # use tokio::runtime::Runtime;
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
+/// # let mut ankaios = Ankaios::builder().control_interface().connect().await.unwrap();
 /// #
 /// let agent_name: String;
 /// # let agent_name = String::new();
@@ -227,7 +243,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use ankaios_sdk::{Ankaios, WorkloadInstanceName};
 /// # use tokio::runtime::Runtime;
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
+/// # let mut ankaios = Ankaios::builder().control_interface().connect().await.unwrap();
 /// #
 /// let workload_instance_name: WorkloadInstanceName;
 /// # let workload_instance_name = WorkloadInstanceName::default();
@@ -242,7 +258,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use ankaios_sdk::{Ankaios, AnkaiosError, WorkloadInstanceName, WorkloadStateEnum};
 /// # use tokio::runtime::Runtime;
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
+/// # let mut ankaios = Ankaios::builder().control_interface().connect().await.unwrap();
 /// #
 /// let workload_instance_name: WorkloadInstanceName;
 /// # let workload_instance_name = WorkloadInstanceName::default();
@@ -267,7 +283,7 @@ pub struct Ankaios {
 
 impl Ankaios {
     /// Creates a new `Ankaios` object and connects to the control interface.
-    /// Deprecated and has been replaced with [`Ankaios::new_with_ci`].
+    /// Deprecated and has been replaced with [`Ankaios::builder`].
     ///
     /// ## Returns
     ///
@@ -278,13 +294,13 @@ impl Ankaios {
     /// [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if an error occurred when connecting.
     /// [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if a timeout occurred when testing the connection.
     #[cfg(feature = "control_interface")]
-    #[deprecated(since = "1.1.0", note = "use `Ankaios::new_with_ci` instead")]
+    #[deprecated(since = "1.1.0", note = "use `Ankaios::builder` instead")]
     pub async fn new() -> Result<Self, AnkaiosError> {
-        Self::new_with_ci().await
+        Self::builder().control_interface().connect().await
     }
 
     /// Creates a new `Ankaios` object with a custom timeout and connects to the control interface.
-    /// Deprecated and has been replaced with [`Ankaios::new_with_ci_and_timeout`].
+    /// Deprecated and has been replaced with [`Ankaios::builder`].
     ///
     /// ## Arguments
     ///
@@ -298,99 +314,24 @@ impl Ankaios {
     ///
     /// [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if an error occurred when connecting.
     #[cfg(feature = "control_interface")]
-    #[deprecated(
-        since = "1.1.0",
-        note = "use `Ankaios::new_with_ci_and_timeout` instead"
-    )]
+    #[deprecated(since = "1.1.0", note = "use `Ankaios::builder` instead")]
     pub async fn new_with_timeout(timeout: Duration) -> Result<Self, AnkaiosError> {
-        Self::new_with_ci_and_timeout(timeout).await
+        Self::builder().control_interface().timeout(timeout).connect().await
     }
 
-    /// Creates a new `Ankaios` object and connects to the control interface, for use from
-    /// inside a workload.
+    /// Creates a builder for constructing an [Ankaios] object, letting the caller pick the
+    /// connection type, depending on which features are enabled, and optionally, a custom timeout.
     ///
     /// ## Returns
     ///
-    /// A [Result] containing the [Ankaios] object if the connection was successful.
-    ///
-    /// ## Errors
-    ///
-    /// [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if an error occurred when connecting.
-    /// [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if a timeout occurred when testing the connection.
-    #[cfg(feature = "control_interface")]
-    pub async fn new_with_ci() -> Result<Self, AnkaiosError> {
-        Self::new_with_ci_and_timeout(Duration::from_secs(DEFAULT_TIMEOUT)).await
-    }
-
-    /// Creates a new `Ankaios` object with a custom timeout and connects to the control
-    /// interface, for use from inside a workload.
-    ///
-    /// ## Arguments
-    ///
-    /// - `timeout`: The maximum time to wait for the requests.
-    ///
-    /// ## Returns
-    ///
-    /// A [Result] containing the [Ankaios] object if the connection was successful.
-    ///
-    /// ## Errors
-    ///
-    /// [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if an error occurred when connecting.
-    #[cfg(feature = "control_interface")]
-    pub async fn new_with_ci_and_timeout(timeout: Duration) -> Result<Self, AnkaiosError> {
-        let (response_sender, response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
-        let connection = Box::new(ControlInterface::new(response_sender));
-        Self::from_connection(connection, response_receiver, timeout).await
-    }
-
-    /// Creates a new `Ankaios` object and connects to an Ankaios server over gRPC, for use from
-    /// outside a workload.
-    ///
-    /// ## Arguments
-    ///
-    /// - `config`: The [`GrpcConfig`] to use when connecting.
-    ///
-    /// ## Returns
-    ///
-    /// A [Result] containing the [Ankaios] object if the connection was successful.
-    ///
-    /// ## Errors
-    ///
-    /// [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if an error occurred when connecting.
-    /// [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if a timeout occurred when testing the connection.
-    #[cfg(feature = "grpc_server_interface")]
-    pub async fn new_with_grpc(config: GrpcConfig) -> Result<Self, AnkaiosError> {
-        Self::new_with_grpc_and_timeout(config, Duration::from_secs(DEFAULT_TIMEOUT)).await
-    }
-
-    /// Creates a new `Ankaios` object with a custom timeout and connects to an Ankaios server
-    /// over gRPC.
-    ///
-    /// ## Arguments
-    ///
-    /// - `config`: The [`GrpcConfig`] to use when connecting;
-    /// - `timeout`: The maximum time to wait for the requests.
-    ///
-    /// ## Returns
-    ///
-    /// A [Result] containing the [Ankaios] object if the connection was successful.
-    ///
-    /// ## Errors
-    ///
-    /// [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if an error occurred when connecting.
-    #[cfg(feature = "grpc_server_interface")]
-    pub async fn new_with_grpc_and_timeout(
-        config: GrpcConfig,
-        timeout: Duration,
-    ) -> Result<Self, AnkaiosError> {
-        let (response_sender, response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
-        let connection = Box::new(GrpcConnection::new(config, response_sender));
-        Self::from_connection(connection, response_receiver, timeout).await
+    /// A new [`AnkaiosBuilder`].
+    #[must_use]
+    pub fn builder() -> AnkaiosBuilder {
+        AnkaiosBuilder::new()
     }
 
     /// Builds an [Ankaios] object from an already-constructed [`Connection`], establishing it
-    /// before returning. Shared by every constructor (control interface, gRPC, ...) so that
-    /// connection setup and the resulting struct's fields stay in one place.
+    /// before returning. Used by the builder.
     async fn from_connection(
         connection: Box<dyn Connection>,
         response_receiver: mpsc::Receiver<Response>,
@@ -1402,6 +1343,100 @@ impl Ankaios {
     }
 }
 
+/// Builder for constructing an [Ankaios] object.
+///
+/// Created via [`Ankaios::builder`]. Pick a connection type with
+/// [`AnkaiosBuilder::control_interface`] or [`AnkaiosBuilder::command_interface`] (whichever
+/// the corresponding feature enables), optionally override the timeout with
+/// [`AnkaiosBuilder::timeout`], then call [`AnkaiosBuilder::connect`].
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// # use ankaios_sdk::Ankaios;
+/// # use tokio::runtime::Runtime;
+/// # Runtime::new().unwrap().block_on(async {
+/// let ankaios = Ankaios::builder().control_interface().connect().await.unwrap();
+/// # })
+/// ```
+pub struct AnkaiosBuilder {
+    connection: Option<(Box<dyn Connection>, mpsc::Receiver<Response>)>,
+    timeout: Duration,
+}
+
+impl AnkaiosBuilder {
+    fn new() -> Self {
+        Self {
+            connection: None,
+            timeout: Duration::from_secs(DEFAULT_TIMEOUT),
+        }
+    }
+
+    /// Connects via the **Control Interface**: the Unix FIFO pipes
+    /// (`/run/ankaios/control_interface/{input,output}`) that an Ankaios **agent** mounts into a
+    /// workload's own container. Use this from inside a workload that is itself run by Ankaios
+    #[cfg(feature = "control_interface")]
+    #[must_use]
+    pub fn control_interface(mut self) -> Self {
+        let (response_sender, response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
+        let connection: Box<dyn Connection> = Box::new(ControlInterface::new(response_sender));
+        self.connection = Some((connection, response_receiver));
+        self
+    }
+
+    /// Connects via the **Command Interface**: a gRPC connection made directly to the Ankaios
+    /// **server**. Use this from outside the cluster — e.g. a standalone tool, service, or CLI
+    /// that isn't itself a workload managed by Ankaios.
+    ///
+    /// ## Arguments
+    ///
+    /// - `config`: The [`GrpcConfig`] (server URL, optional mTLS material) to use when connecting.
+    #[cfg(feature = "grpc_server_interface")]
+    #[must_use]
+    pub fn command_interface(mut self, config: GrpcConfig) -> Self {
+        let (response_sender, response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
+        let connection: Box<dyn Connection> =
+            Box::new(GrpcConnection::new(config, response_sender));
+        self.connection = Some((connection, response_receiver));
+        self
+    }
+
+    /// Sets a custom timeout for the requests.
+    ///
+    /// ## Arguments
+    ///
+    /// - `timeout`: The maximum time to wait for the requests.
+    #[must_use]
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Establishes the connection configured on this builder and returns the resulting
+    /// [Ankaios] object.
+    ///
+    /// ## Returns
+    ///
+    /// A [Result] containing the [Ankaios] object if the connection was successful.
+    ///
+    /// ## Errors
+    ///
+    /// [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if no connection type
+    /// was configured, or if an error occurred when connecting.
+    /// [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if a timeout occurred when
+    /// testing the connection.
+    pub async fn connect(self) -> Result<Ankaios, AnkaiosError> {
+        let (connection, response_receiver) = self.connection.ok_or_else(|| {
+            AnkaiosError::ConnectionError(
+                "No connection type configured; call `.control_interface()` or \
+                 `.command_interface(..)` before `.connect()`."
+                    .to_owned(),
+            )
+        })?;
+        Ankaios::from_connection(connection, response_receiver, self.timeout).await
+    }
+}
+
 impl Drop for Ankaios {
     fn drop(&mut self) {
         log::trace!("Dropping Ankaios");
@@ -1514,10 +1549,7 @@ mod tests {
         )
         .await;
         assert!(result.is_err());
-        assert!(matches!(
-            result,
-            Err(AnkaiosError::ConnectionError(_))
-        ));
+        assert!(matches!(result, Err(AnkaiosError::ConnectionError(_))));
     }
 
     #[cfg(feature = "grpc_server_interface")]
@@ -1529,11 +1561,15 @@ mod tests {
         // to connect; the SDK doesn't stand up a real (or fake) gRPC server to test the success
         // path against. Port 0 is never a valid connection target, so this fails fast.
         let config = super::GrpcConfig::new("http://127.0.0.1:0");
-        let result = Ankaios::new_with_grpc(config).await;
+        let result = Ankaios::builder().command_interface(config).connect().await;
         assert!(matches!(result, Err(AnkaiosError::ConnectionError(_))));
 
         let config = super::GrpcConfig::new("http://127.0.0.1:0");
-        let result = Ankaios::new_with_grpc_and_timeout(config, Duration::from_secs(5)).await;
+        let result = Ankaios::builder()
+            .command_interface(config)
+            .timeout(Duration::from_secs(5))
+            .connect()
+            .await;
         assert!(matches!(result, Err(AnkaiosError::ConnectionError(_))));
     }
 

--- a/src/ankaios.rs
+++ b/src/ankaios.rs
@@ -25,10 +25,10 @@ use tokio::time::{Duration, sleep, timeout as tokio_timeout};
 use crate::components::connection::Connection;
 #[cfg(test)]
 use crate::components::connection::MockConnection;
+#[cfg(feature = "command_interface")]
+use crate::components::connection::command_interface::{CommandInterfaceConnection, GrpcConfig};
 #[cfg(feature = "control_interface")]
-use crate::components::connection::control_interface::ControlInterface;
-#[cfg(feature = "grpc_server_interface")]
-use crate::components::connection::grpc_interface::{GrpcConfig, GrpcConnection};
+use crate::components::connection::control_interface::ControlInterfaceConnection;
 
 use crate::components::event_types::{EventEntry, EventsCampaignResponse};
 use crate::components::log_types::{LogCampaignResponse, LogsRequest};
@@ -55,7 +55,8 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 
 /// This struct is used to interact with [Ankaios] using an intuitive API.
 /// The struct automatically handles the session creation and the requests
-/// and responses sent and received over the Control Interface.
+/// and responses sent and received over the configured connection (either
+/// Control Interface or Command Interface).
 ///
 /// [Ankaios]: https://eclipse-ankaios.github.io/ankaios
 ///
@@ -88,7 +89,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # })
 /// ```
 ///
-/// ## Create an Ankaios object, connect and disconnect from the grpc command interface:
+/// ## Create an Ankaios object, connect and disconnect from the command interface:
 ///
 /// ```rust,no_run
 /// use ankaios_sdk::{Ankaios, GrpcConfig};
@@ -275,7 +276,8 @@ pub struct Ankaios {
     /// The receiver end of the channel used to receive responses from Ankaios.
     response_receiver: mpsc::Receiver<Response>,
     /// The connection instance that is used to communicate with Ankaios, either via the
-    /// control interface or, with the `grpc` feature enabled, directly over gRPC.
+    /// control interface or the command interface, depending on whether the SDK is used from
+    /// inside or outside a workload and which feature is enabled.
     connection: Box<dyn Connection>,
     /// The timeout used for the requests.
     pub timeout: Duration,
@@ -353,7 +355,7 @@ impl Ankaios {
         Ok(object)
     }
 
-    /// Sends a request to the Control Interface and waits for the response.
+    /// Sends a request to the configured connection and waits for the response.
     ///
     /// ## Arguments
     ///
@@ -1383,7 +1385,8 @@ impl AnkaiosBuilder {
     #[must_use]
     pub fn control_interface(mut self) -> Self {
         let (response_sender, response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
-        let connection: Box<dyn Connection> = Box::new(ControlInterface::new(response_sender));
+        let connection: Box<dyn Connection> =
+            Box::new(ControlInterfaceConnection::new(response_sender));
         self.connection = Some((connection, response_receiver));
         self
     }
@@ -1395,12 +1398,12 @@ impl AnkaiosBuilder {
     /// ## Arguments
     ///
     /// - `config`: The [`GrpcConfig`] (server URL, optional mTLS material) to use when connecting.
-    #[cfg(feature = "grpc_server_interface")]
+    #[cfg(feature = "command_interface")]
     #[must_use]
     pub fn command_interface(mut self, config: GrpcConfig) -> Self {
         let (response_sender, response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
         let connection: Box<dyn Connection> =
-            Box::new(GrpcConnection::new(config, response_sender));
+            Box::new(CommandInterfaceConnection::new(config, response_sender));
         self.connection = Some((connection, response_receiver));
         self
     }
@@ -1556,9 +1559,9 @@ mod tests {
         assert!(matches!(result, Err(AnkaiosError::ConnectionError(_))));
     }
 
-    #[cfg(feature = "grpc_server_interface")]
+    #[cfg(feature = "command_interface")]
     #[tokio::test]
-    async fn itest_create_ankaios_with_grpc() {
+    async fn itest_create_ankaios_with_command_interface() {
         let _guard = MOCKALL_SYNC.lock().await;
 
         // No Ankaios server is running in the test environment, so these are expected to fail

--- a/src/ankaios.rs
+++ b/src/ankaios.rs
@@ -97,7 +97,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # Runtime::new().unwrap().block_on(async {
 ///
 /// # let server_url = String::new();
-/// let grpc_config = GrpcConfig::new(server_url);
+/// let grpc_config = GrpcConfig::insecure(server_url);
 /// let ankaios = Ankaios::builder().command_interface(grpc_config).connect().await.unwrap();
 /// /* */
 /// drop(ankaios);
@@ -316,7 +316,11 @@ impl Ankaios {
     #[cfg(feature = "control_interface")]
     #[deprecated(since = "1.1.0", note = "use `Ankaios::builder` instead")]
     pub async fn new_with_timeout(timeout: Duration) -> Result<Self, AnkaiosError> {
-        Self::builder().control_interface().timeout(timeout).connect().await
+        Self::builder()
+            .control_interface()
+            .timeout(timeout)
+            .connect()
+            .await
     }
 
     /// Creates a builder for constructing an [Ankaios] object, letting the caller pick the
@@ -1560,11 +1564,11 @@ mod tests {
         // No Ankaios server is running in the test environment, so these are expected to fail
         // to connect; the SDK doesn't stand up a real (or fake) gRPC server to test the success
         // path against. Port 0 is never a valid connection target, so this fails fast.
-        let config = super::GrpcConfig::new("http://127.0.0.1:0");
+        let config = super::GrpcConfig::insecure("http://127.0.0.1:0");
         let result = Ankaios::builder().command_interface(config).connect().await;
         assert!(matches!(result, Err(AnkaiosError::ConnectionError(_))));
 
-        let config = super::GrpcConfig::new("http://127.0.0.1:0");
+        let config = super::GrpcConfig::insecure("http://127.0.0.1:0");
         let result = Ankaios::builder()
             .command_interface(config)
             .timeout(Duration::from_secs(5))

--- a/src/ankaios.rs
+++ b/src/ankaios.rs
@@ -22,8 +22,14 @@ use std::vec;
 use tokio::sync::mpsc;
 use tokio::time::{Duration, sleep, timeout as tokio_timeout};
 
-#[cfg_attr(test, mockall_double::double)]
-use crate::components::control_interface::ControlInterface;
+use crate::components::connection::Connection;
+#[cfg(test)]
+use crate::components::connection::MockConnection;
+#[cfg(feature = "control_interface")]
+use crate::components::connection::control_interface::ControlInterface;
+#[cfg(feature = "grpc_server_interface")]
+use crate::components::connection::grpc_interface::{GrpcConfig, GrpcConnection};
+
 use crate::components::event_types::{EventEntry, EventsCampaignResponse};
 use crate::components::log_types::{LogCampaignResponse, LogsRequest};
 use crate::components::manifest::{CONFIGS_PREFIX, Manifest};
@@ -63,7 +69,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// #
 /// # Runtime::new().unwrap().block_on(async {
 ///
-/// let ankaios = Ankaios::new().await.unwrap();
+/// let ankaios = Ankaios::new_with_ci().await.unwrap();
 /// /* */
 /// drop(ankaios);
 /// # })
@@ -78,7 +84,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// #
 /// # Runtime::new().unwrap().block_on(async {
 /// #
-/// let ankaios = Ankaios::new_with_timeout(Duration::from_secs(5)).await.unwrap();
+/// let ankaios = Ankaios::new_with_ci_and_timeout(Duration::from_secs(5)).await.unwrap();
 /// # })
 /// ```
 ///
@@ -89,7 +95,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use tokio::runtime::Runtime;
 /// #
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new().await.unwrap();
+/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
 /// #
 /// let manifest: Manifest;
 /// # let manifest = Manifest::from_string("").unwrap();
@@ -105,7 +111,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use tokio::runtime::Runtime;
 /// #
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new().await.unwrap();
+/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
 /// #
 /// let manifest: Manifest;
 /// # let manifest = Manifest::from_string("").unwrap();
@@ -121,7 +127,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use tokio::runtime::Runtime;
 /// #
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new().await.unwrap();
+/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
 /// #
 /// let workload: Workload;
 /// # let workload = Workload::builder().build().unwrap();
@@ -137,7 +143,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use tokio::runtime::Runtime;
 /// #
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new().await.unwrap();
+/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
 /// #
 /// let workload_name: String;
 /// # let workload_name = String::new();
@@ -152,7 +158,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use ankaios_sdk::Ankaios;
 /// # use tokio::runtime::Runtime;
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new().await.unwrap();
+/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
 /// #
 /// let workload_name: String;
 /// # let workload_name = String::new();
@@ -167,7 +173,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use ankaios_sdk::Ankaios;
 /// # use tokio::runtime::Runtime;
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new().await.unwrap();
+/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
 /// #
 /// let state = ankaios.get_state(Vec::default()).await.unwrap();
 /// println!("{:?}", state);
@@ -180,7 +186,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use ankaios_sdk::Ankaios;
 /// # use tokio::runtime::Runtime;
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new().await.unwrap();
+/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
 /// #
 /// let agents = ankaios.get_agents().await.unwrap();
 /// println!("{:?}", agents);
@@ -193,7 +199,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use ankaios_sdk::Ankaios;
 /// # use tokio::runtime::Runtime;
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new().await.unwrap();
+/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
 /// #
 /// let workload_states_collection = ankaios.get_workload_states().await.unwrap();
 /// let workload_states = workload_states_collection.as_list();
@@ -206,7 +212,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use ankaios_sdk::Ankaios;
 /// # use tokio::runtime::Runtime;
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new().await.unwrap();
+/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
 /// #
 /// let agent_name: String;
 /// # let agent_name = String::new();
@@ -221,7 +227,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use ankaios_sdk::{Ankaios, WorkloadInstanceName};
 /// # use tokio::runtime::Runtime;
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new().await.unwrap();
+/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
 /// #
 /// let workload_instance_name: WorkloadInstanceName;
 /// # let workload_instance_name = WorkloadInstanceName::default();
@@ -236,7 +242,7 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # use ankaios_sdk::{Ankaios, AnkaiosError, WorkloadInstanceName, WorkloadStateEnum};
 /// # use tokio::runtime::Runtime;
 /// # Runtime::new().unwrap().block_on(async {
-/// # let mut ankaios = Ankaios::new().await.unwrap();
+/// # let mut ankaios = Ankaios::new_with_ci().await.unwrap();
 /// #
 /// let workload_instance_name: WorkloadInstanceName;
 /// # let workload_instance_name = WorkloadInstanceName::default();
@@ -250,16 +256,18 @@ pub(crate) const CHANNEL_SIZE: usize = 100;
 /// # })
 /// ```
 pub struct Ankaios {
-    /// The receiver end of the channel used to receive responses from the Control Interface.
+    /// The receiver end of the channel used to receive responses from Ankaios.
     response_receiver: mpsc::Receiver<Response>,
-    /// The control interface instance that is used to communicate with the Control Interface.
-    control_interface: ControlInterface,
+    /// The connection instance that is used to communicate with Ankaios, either via the
+    /// control interface or, with the `grpc` feature enabled, directly over gRPC.
+    connection: Box<dyn Connection>,
     /// The timeout used for the requests.
     pub timeout: Duration,
 }
 
 impl Ankaios {
-    /// Creates a new `Ankaios` object and connects to the Control Interface.
+    /// Creates a new `Ankaios` object and connects to the control interface.
+    /// Deprecated and has been replaced with [`Ankaios::new_with_ci`].
     ///
     /// ## Returns
     ///
@@ -267,13 +275,16 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if an error occurred when connecting.
+    /// [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if an error occurred when connecting.
     /// [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if a timeout occurred when testing the connection.
+    #[cfg(feature = "control_interface")]
+    #[deprecated(since = "1.1.0", note = "use `Ankaios::new_with_ci` instead")]
     pub async fn new() -> Result<Self, AnkaiosError> {
-        Self::new_with_timeout(Duration::from_secs(DEFAULT_TIMEOUT)).await
+        Self::new_with_ci().await
     }
 
-    /// Creates a new `Ankaios` object with a custom timeout and connects to the Control Interface.
+    /// Creates a new `Ankaios` object with a custom timeout and connects to the control interface.
+    /// Deprecated and has been replaced with [`Ankaios::new_with_ci_and_timeout`].
     ///
     /// ## Arguments
     ///
@@ -285,16 +296,115 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if an error occurred when connecting.
+    /// [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if an error occurred when connecting.
+    #[cfg(feature = "control_interface")]
+    #[deprecated(
+        since = "1.1.0",
+        note = "use `Ankaios::new_with_ci_and_timeout` instead"
+    )]
     pub async fn new_with_timeout(timeout: Duration) -> Result<Self, AnkaiosError> {
+        Self::new_with_ci_and_timeout(timeout).await
+    }
+
+    /// Creates a new `Ankaios` object and connects to the control interface, for use from
+    /// inside a workload.
+    ///
+    /// ## Returns
+    ///
+    /// A [Result] containing the [Ankaios] object if the connection was successful.
+    ///
+    /// ## Errors
+    ///
+    /// [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if an error occurred when connecting.
+    /// [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if a timeout occurred when testing the connection.
+    #[cfg(feature = "control_interface")]
+    pub async fn new_with_ci() -> Result<Self, AnkaiosError> {
+        Self::new_with_ci_and_timeout(Duration::from_secs(DEFAULT_TIMEOUT)).await
+    }
+
+    /// Creates a new `Ankaios` object with a custom timeout and connects to the control
+    /// interface, for use from inside a workload.
+    ///
+    /// ## Arguments
+    ///
+    /// - `timeout`: The maximum time to wait for the requests.
+    ///
+    /// ## Returns
+    ///
+    /// A [Result] containing the [Ankaios] object if the connection was successful.
+    ///
+    /// ## Errors
+    ///
+    /// [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if an error occurred when connecting.
+    #[cfg(feature = "control_interface")]
+    pub async fn new_with_ci_and_timeout(timeout: Duration) -> Result<Self, AnkaiosError> {
         let (response_sender, response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
+        let connection = Box::new(ControlInterface::new(response_sender));
+        Self::from_connection(connection, response_receiver, timeout).await
+    }
+
+    /// Creates a new `Ankaios` object and connects to an Ankaios server over gRPC, for use from
+    /// outside a workload.
+    ///
+    /// ## Arguments
+    ///
+    /// - `config`: The [`GrpcConfig`] to use when connecting.
+    ///
+    /// ## Returns
+    ///
+    /// A [Result] containing the [Ankaios] object if the connection was successful.
+    ///
+    /// ## Errors
+    ///
+    /// [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if an error occurred when connecting.
+    /// [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if a timeout occurred when testing the connection.
+    #[cfg(feature = "grpc_server_interface")]
+    pub async fn new_with_grpc(config: GrpcConfig) -> Result<Self, AnkaiosError> {
+        Self::new_with_grpc_and_timeout(config, Duration::from_secs(DEFAULT_TIMEOUT)).await
+    }
+
+    /// Creates a new `Ankaios` object with a custom timeout and connects to an Ankaios server
+    /// over gRPC.
+    ///
+    /// ## Arguments
+    ///
+    /// - `config`: The [`GrpcConfig`] to use when connecting;
+    /// - `timeout`: The maximum time to wait for the requests.
+    ///
+    /// ## Returns
+    ///
+    /// A [Result] containing the [Ankaios] object if the connection was successful.
+    ///
+    /// ## Errors
+    ///
+    /// [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if an error occurred when connecting.
+    #[cfg(feature = "grpc_server_interface")]
+    pub async fn new_with_grpc_and_timeout(
+        config: GrpcConfig,
+        timeout: Duration,
+    ) -> Result<Self, AnkaiosError> {
+        let (response_sender, response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
+        let connection = Box::new(GrpcConnection::new(config, response_sender));
+        Self::from_connection(connection, response_receiver, timeout).await
+    }
+
+    /// Builds an [Ankaios] object from an already-constructed [`Connection`], establishing it
+    /// before returning. Shared by every constructor (control interface, gRPC, ...) so that
+    /// connection setup and the resulting struct's fields stay in one place.
+    async fn from_connection(
+        connection: Box<dyn Connection>,
+        response_receiver: mpsc::Receiver<Response>,
+        timeout: Duration,
+    ) -> Result<Self, AnkaiosError> {
+        // Construct first, then connect: this way, `object` (and thus `impl Drop for Ankaios`,
+        // which disconnects) is still torn down correctly even if `connect` returns an error,
+        // e.g. cleaning up tasks that `connect` may have already spawned before timing out.
         let mut object = Self {
             response_receiver,
-            control_interface: ControlInterface::new(response_sender),
+            connection,
             timeout,
         };
-
-        object.control_interface.connect(timeout).await?;
+        object.connection.connect(timeout).await?;
         Ok(object)
     }
 
@@ -310,7 +420,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`ConnectionClosedError`](AnkaiosError::ConnectionClosedError) if the connection was closed.
     async fn send_request(
@@ -318,7 +428,7 @@ impl Ankaios {
         request: impl Request + 'static,
     ) -> Result<Response, AnkaiosError> {
         let request_id = request.get_id();
-        self.control_interface.write_request(request).await?;
+        self.connection.write_request(request.to_proto()).await?;
         loop {
             match tokio_timeout(self.timeout, self.response_receiver.recv()).await {
                 Ok(Some(response)) => {
@@ -333,7 +443,7 @@ impl Ankaios {
                 }
                 Ok(None) => {
                     log::error!("Reading thread closed unexpectedly.");
-                    return Err(AnkaiosError::ControlInterfaceError(
+                    return Err(AnkaiosError::ConnectionError(
                         "Reading thread closed.".to_owned(),
                     ));
                 }
@@ -357,7 +467,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -407,7 +517,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -457,7 +567,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -514,7 +624,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -541,7 +651,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -593,7 +703,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -647,7 +757,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -698,7 +808,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -722,7 +832,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -741,7 +851,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -780,7 +890,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -825,7 +935,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -864,7 +974,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -913,7 +1023,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -931,7 +1041,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -955,7 +1065,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -979,7 +1089,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -1012,7 +1122,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -1039,7 +1149,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response;
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -1069,7 +1179,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response or waiting for the state to be reached.
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -1115,7 +1225,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response or waiting for the state to be reached.
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -1140,8 +1250,7 @@ impl Ankaios {
                     accepted_workload_names,
                     logs_receiver,
                 );
-                self.control_interface
-                    .add_log_campaign(request_id, logs_sender);
+                self.connection.add_log_campaign(request_id, logs_sender);
                 Ok(log_campaign_response)
             }
             ResponseType::Error(error) => {
@@ -1165,7 +1274,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response or waiting for the state to be reached.
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -1175,7 +1284,7 @@ impl Ankaios {
         log_campaign_response: LogCampaignResponse,
     ) -> Result<(), AnkaiosError> {
         let logs_cancel_request = LogsCancelRequest::new(log_campaign_response.get_request_id());
-        self.control_interface
+        self.connection
             .remove_log_campaign(&logs_cancel_request.get_id());
         let response = self.send_request(logs_cancel_request).await?;
 
@@ -1205,7 +1314,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response or waiting for the state to be reached.
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -1234,7 +1343,7 @@ impl Ankaios {
                     log::error!("Error while sending initial event: '{err}'");
                 });
 
-                self.control_interface
+                self.connection
                     .add_events_campaign(request_id, events_sender);
                 Ok(events_campaign_response)
             }
@@ -1259,7 +1368,7 @@ impl Ankaios {
     ///
     /// ## Errors
     ///
-    /// - [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected;
+    /// - [`AnkaiosError`]::[`ConnectionError`](AnkaiosError::ConnectionError) if not connected;
     /// - [`AnkaiosError`]::[`TimeoutError`](AnkaiosError::TimeoutError) if the timeout was reached while waiting for the response or waiting for the state to be reached.
     /// - [`AnkaiosError`]::[`AnkaiosResponseError`](AnkaiosError::AnkaiosResponseError) if [Ankaios](https://eclipse-ankaios.github.io/ankaios) returned an error;
     /// - [`AnkaiosError`]::[`ResponseError`](AnkaiosError::ResponseError) if the response has the wrong type;
@@ -1270,7 +1379,7 @@ impl Ankaios {
     ) -> Result<(), AnkaiosError> {
         let events_cancel_request =
             EventsCancelRequest::new(events_campaign_response.get_request_id());
-        self.control_interface
+        self.connection
             .remove_events_campaign(&events_cancel_request.get_id());
         let response = self.send_request(events_cancel_request).await?;
 
@@ -1296,7 +1405,7 @@ impl Ankaios {
 impl Drop for Ankaios {
     fn drop(&mut self) {
         log::trace!("Dropping Ankaios");
-        self.control_interface.disconnect().unwrap_or_else(|err| {
+        self.connection.disconnect().unwrap_or_else(|err| {
             log::error!("Error while disconnecting: '{err}'");
         });
     }
@@ -1311,14 +1420,12 @@ impl Drop for Ankaios {
 //////////////////////////////////////////////////////////////////////////////
 
 #[cfg(test)]
-fn generate_test_ankaios(
-    mock_control_interface: ControlInterface,
-) -> (Ankaios, mpsc::Sender<Response>) {
+fn generate_test_ankaios(mock_connection: MockConnection) -> (Ankaios, mpsc::Sender<Response>) {
     let (response_sender, response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
     (
         Ankaios {
             response_receiver,
-            control_interface: mock_control_interface,
+            connection: Box::new(mock_connection),
             timeout: Duration::from_millis(50),
         },
         response_sender,
@@ -1334,17 +1441,15 @@ mod tests {
     };
 
     use super::{
-        AGENTS_PREFIX, AgentAttributes, Ankaios, AnkaiosError, CONFIGS_PREFIX, CompleteState,
-        ControlInterface, DEFAULT_TIMEOUT, EventsCampaignResponse, Response,
-        WORKLOAD_STATES_PREFIX, WorkloadInstanceName, WorkloadStateEnum, generate_test_ankaios,
+        AGENTS_PREFIX, AgentAttributes, Ankaios, AnkaiosError, CHANNEL_SIZE, CONFIGS_PREFIX,
+        CompleteState, DEFAULT_TIMEOUT, EventsCampaignResponse, Response, WORKLOAD_STATES_PREFIX,
+        WorkloadInstanceName, WorkloadStateEnum, generate_test_ankaios,
     };
+    use crate::ankaios_api::ank_base::Request as AnkaiosRequest;
+    use crate::components::connection::MockConnection;
     use crate::components::{
         complete_state::generate_complete_state_proto,
         manifest::generate_test_manifest,
-        request::{
-            AnkaiosLogsRequest, EventsCancelRequest, EventsRequest, GetStateRequest,
-            LogsCancelRequest, Request, UpdateStateRequest,
-        },
         response::generate_test_response_update_state_success,
         workload_mod::{WORKLOADS_PREFIX, test_helpers::generate_test_workload},
     };
@@ -1362,24 +1467,26 @@ mod tests {
     async fn itest_create_ankaios() {
         let _guard = MOCKALL_SYNC.lock().await;
 
-        let ci_new_context = ControlInterface::new_context();
-        let mut ci_mock = ControlInterface::default();
-
-        ci_mock
+        let mut mock_connection = MockConnection::default();
+        mock_connection
             .expect_connect()
             .times(1)
             .with(mockall::predicate::eq(Duration::from_millis(50)))
             .returning(|_| Ok(()));
+        mock_connection
+            .expect_disconnect()
+            .times(1)
+            .returning(|| Ok(()));
 
-        ci_mock.expect_disconnect().times(1).returning(|| Ok(()));
+        let (_response_sender, response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
 
-        ci_new_context.expect().return_once(move |_| ci_mock);
-
-        // Create Ankaios handle
-        let ankaios_handle = tokio::spawn(Ankaios::new_with_timeout(Duration::from_millis(50)));
-
-        // Create Ankaios fully and check the connection
-        let ankaios = ankaios_handle.await.unwrap();
+        // Exercises the same connection-setup wiring that `new_with_timeout` delegates to.
+        let ankaios = Ankaios::from_connection(
+            Box::new(mock_connection),
+            response_receiver,
+            Duration::from_millis(50),
+        )
+        .await;
         assert!(ankaios.is_ok());
     }
 
@@ -1387,28 +1494,47 @@ mod tests {
     async fn itest_timeout_while_connecting() {
         let _guard = MOCKALL_SYNC.lock().await;
 
-        let ci_new_context = ControlInterface::new_context();
-        let mut ci_mock = ControlInterface::default();
-
-        ci_mock
+        let mut mock_connection = MockConnection::default();
+        mock_connection
             .expect_connect()
             .with(mockall::predicate::eq(Duration::from_secs(DEFAULT_TIMEOUT)))
             .times(1)
-            .returning(|_| Err(AnkaiosError::ControlInterfaceError(String::default())));
-        ci_mock.expect_disconnect().times(1).returning(|| Ok(()));
+            .returning(|_| Err(AnkaiosError::ConnectionError(String::default())));
+        mock_connection
+            .expect_disconnect()
+            .times(1)
+            .returning(|| Ok(()));
 
-        ci_new_context.expect().return_once(move |_| ci_mock);
+        let (_response_sender, response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
 
-        // Create Ankaios handle
-        let ankaios_handle = tokio::spawn(Ankaios::new());
-
-        // Create Ankaios fully and check the connection
-        let result = ankaios_handle.await.unwrap();
+        let result = Ankaios::from_connection(
+            Box::new(mock_connection),
+            response_receiver,
+            Duration::from_secs(DEFAULT_TIMEOUT),
+        )
+        .await;
         assert!(result.is_err());
         assert!(matches!(
             result,
-            Err(AnkaiosError::ControlInterfaceError(_))
+            Err(AnkaiosError::ConnectionError(_))
         ));
+    }
+
+    #[cfg(feature = "grpc_server_interface")]
+    #[tokio::test]
+    async fn itest_create_ankaios_with_grpc() {
+        let _guard = MOCKALL_SYNC.lock().await;
+
+        // No Ankaios server is running in the test environment, so these are expected to fail
+        // to connect; the SDK doesn't stand up a real (or fake) gRPC server to test the success
+        // path against. Port 0 is never a valid connection target, so this fails fast.
+        let config = super::GrpcConfig::new("http://127.0.0.1:0");
+        let result = Ankaios::new_with_grpc(config).await;
+        assert!(matches!(result, Err(AnkaiosError::ConnectionError(_))));
+
+        let config = super::GrpcConfig::new("http://127.0.0.1:0");
+        let result = Ankaios::new_with_grpc_and_timeout(config, Duration::from_secs(5)).await;
+        assert!(matches!(result, Err(AnkaiosError::ConnectionError(_))));
     }
 
     #[tokio::test]
@@ -1418,11 +1544,11 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .return_once(move |request: GetStateRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -1433,14 +1559,14 @@ mod tests {
         // Prepare handle for getting the state
         let method_handle = tokio::spawn(async move { ank.get_state(Vec::default()).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let complete_state = CompleteState::default();
         let response = Response {
             content: super::ResponseType::CompleteState(Box::new(complete_state.clone())),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -1459,11 +1585,11 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .return_once(move |request: GetStateRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -1474,7 +1600,7 @@ mod tests {
         // Prepare handle for getting the state
         let method_handle = tokio::spawn(async move { ank.get_state(Vec::default()).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let _request = request_receiver.await.unwrap();
 
         // Fabricate a response
@@ -1499,11 +1625,11 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .return_once(move |request: GetStateRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -1514,13 +1640,13 @@ mod tests {
         // Prepare handle for getting the state
         let method_handle = tokio::spawn(async move { ank.get_state(Vec::default()).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let response = Response {
             content: super::ResponseType::Error("test".to_owned()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -1539,11 +1665,11 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .return_once(move |request: GetStateRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -1554,13 +1680,13 @@ mod tests {
         // Prepare handle for getting the state
         let method_handle = tokio::spawn(async move { ank.get_state(Vec::default()).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let response = Response {
             content: super::ResponseType::UpdateStateSuccess(Box::default()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -1583,19 +1709,19 @@ mod tests {
         let manifest = generate_test_manifest();
         let masks = manifest.calculate_masks();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &UpdateStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::UpdateStateRequest(content)) => {
                         content.update_mask == masks
                     }
                     _ => false,
                 },
             )
-            .return_once(|request: UpdateStateRequest| {
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -1606,11 +1732,11 @@ mod tests {
         // Prepare handle for applying the manifest
         let method_handle = tokio::spawn(async move { ank.apply_manifest(manifest).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
-        let response = generate_test_response_update_state_success(request.get_id());
+        let response = generate_test_response_update_state_success(request.request_id.clone());
 
         // Send the response
         response_sender.send(response).await.unwrap();
@@ -1632,19 +1758,19 @@ mod tests {
         let manifest = generate_test_manifest();
         let masks = manifest.calculate_masks();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &UpdateStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::UpdateStateRequest(content)) => {
                         content.update_mask == masks
                     }
                     _ => false,
                 },
             )
-            .return_once(|request: UpdateStateRequest| {
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -1655,13 +1781,13 @@ mod tests {
         // Prepare handle for applying the manifest
         let method_handle = tokio::spawn(async move { ank.apply_manifest(manifest).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let response = Response {
             content: super::ResponseType::Error("test".to_owned()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -1684,19 +1810,19 @@ mod tests {
         let manifest = generate_test_manifest();
         let masks = manifest.calculate_masks();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &UpdateStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::UpdateStateRequest(content)) => {
                         content.update_mask == masks
                     }
                     _ => false,
                 },
             )
-            .return_once(|request: UpdateStateRequest| {
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -1707,13 +1833,13 @@ mod tests {
         // Prepare handle for applying the manifest
         let method_handle = tokio::spawn(async move { ank.apply_manifest(manifest).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let response = Response {
             content: super::ResponseType::CompleteState(Box::default()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -1736,19 +1862,19 @@ mod tests {
         let manifest = generate_test_manifest();
         let masks = manifest.calculate_masks();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &UpdateStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::UpdateStateRequest(content)) => {
                         content.update_mask == masks
                     }
                     _ => false,
                 },
             )
-            .return_once(|request: UpdateStateRequest| {
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -1759,11 +1885,11 @@ mod tests {
         // Prepare handle for deleting the manifest
         let method_handle = tokio::spawn(async move { ank.delete_manifest(manifest).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
-        let response = generate_test_response_update_state_success(request.get_id());
+        let response = generate_test_response_update_state_success(request.request_id.clone());
 
         // Send the response
         response_sender.send(response).await.unwrap();
@@ -1785,19 +1911,19 @@ mod tests {
         let manifest = generate_test_manifest();
         let masks = manifest.calculate_masks();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &UpdateStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::UpdateStateRequest(content)) => {
                         content.update_mask == masks
                     }
                     _ => false,
                 },
             )
-            .return_once(|request: UpdateStateRequest| {
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -1808,13 +1934,13 @@ mod tests {
         // Prepare handle for deleting the manifest
         let method_handle = tokio::spawn(async move { ank.delete_manifest(manifest).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let response = Response {
             content: super::ResponseType::Error("test".to_owned()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -1837,19 +1963,19 @@ mod tests {
         let manifest = generate_test_manifest();
         let masks = manifest.calculate_masks();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &UpdateStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::UpdateStateRequest(content)) => {
                         content.update_mask == masks
                     }
                     _ => false,
                 },
             )
-            .return_once(|request: UpdateStateRequest| {
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -1860,13 +1986,13 @@ mod tests {
         // Prepare handle for deleting the manifest
         let method_handle = tokio::spawn(async move { ank.delete_manifest(manifest).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let response = Response {
             content: super::ResponseType::CompleteState(Box::default()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -1889,19 +2015,19 @@ mod tests {
         let workload = generate_test_workload("agent_Test", "workload_Test", "podman");
         let masks = workload.masks.clone();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &UpdateStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::UpdateStateRequest(content)) => {
                         content.update_mask == masks
                     }
                     _ => false,
                 },
             )
-            .return_once(|request: UpdateStateRequest| {
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -1912,11 +2038,11 @@ mod tests {
         // Prepare handle for applying the workload
         let method_handle = tokio::spawn(async move { ank.apply_workload(workload).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
-        let response = generate_test_response_update_state_success(request.get_id());
+        let response = generate_test_response_update_state_success(request.request_id.clone());
 
         // Send the response
         response_sender.send(response).await.unwrap();
@@ -1938,19 +2064,19 @@ mod tests {
         let workload = generate_test_workload("agent_Test", "workload_Test", "podman");
         let masks = workload.masks.clone();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &UpdateStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::UpdateStateRequest(content)) => {
                         content.update_mask == masks
                     }
                     _ => false,
                 },
             )
-            .return_once(|request: UpdateStateRequest| {
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -1961,13 +2087,13 @@ mod tests {
         // Prepare handle for applying the workload
         let method_handle = tokio::spawn(async move { ank.apply_workload(workload).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let response = Response {
             content: super::ResponseType::Error("test".to_owned()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -1990,19 +2116,19 @@ mod tests {
         let workload = generate_test_workload("agent_Test", "workload_Test", "podman");
         let masks = workload.masks.clone();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &UpdateStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::UpdateStateRequest(content)) => {
                         content.update_mask == masks
                     }
                     _ => false,
                 },
             )
-            .return_once(|request: UpdateStateRequest| {
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2013,13 +2139,13 @@ mod tests {
         // Prepare handle for applying the workload
         let method_handle = tokio::spawn(async move { ank.apply_workload(workload).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let response = Response {
             content: super::ResponseType::CompleteState(Box::default()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -2042,19 +2168,19 @@ mod tests {
         workload.masks.clear();
         let main_mask = workload.main_mask.clone();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &UpdateStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::UpdateStateRequest(content)) => {
                         content.update_mask == vec![main_mask.clone()]
                     }
                     _ => false,
                 },
             )
-            .return_once(|request: UpdateStateRequest| {
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2065,7 +2191,7 @@ mod tests {
         let method_handle = tokio::spawn(async move { ank.apply_workload(workload).await });
 
         let request = request_receiver.await.unwrap();
-        let response = generate_test_response_update_state_success(request.get_id());
+        let response = generate_test_response_update_state_success(request.request_id.clone());
         response_sender.send(response).await.unwrap();
 
         let ret = method_handle.await.unwrap().unwrap();
@@ -2080,19 +2206,19 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &GetStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::CompleteStateRequest(content)) => {
                         content.field_mask == vec![format!("{WORKLOADS_PREFIX}.workload_Test")]
                     }
                     _ => false,
                 },
             )
-            .return_once(move |request: GetStateRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2104,7 +2230,7 @@ mod tests {
         let method_handle =
             tokio::spawn(async move { ank.get_workload("workload_Test".to_owned()).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
@@ -2112,7 +2238,7 @@ mod tests {
         let complete_state = CompleteState::new_from_workloads(vec![workload.clone()]);
         let response = Response {
             content: super::ResponseType::CompleteState(Box::new(complete_state.clone())),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -2132,19 +2258,17 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .withf(
-                |request: &UpdateStateRequest| match &request.request.request_content {
-                    Some(RequestContent::UpdateStateRequest(content)) => {
-                        content.update_mask == vec![format!("{WORKLOADS_PREFIX}.workload_Test")]
-                    }
-                    _ => false,
-                },
-            )
-            .return_once(|request: UpdateStateRequest| {
+            .withf(|request: &AnkaiosRequest| match &request.request_content {
+                Some(RequestContent::UpdateStateRequest(content)) => {
+                    content.update_mask == vec![format!("{WORKLOADS_PREFIX}.workload_Test")]
+                }
+                _ => false,
+            })
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2156,11 +2280,11 @@ mod tests {
         let method_handle =
             tokio::spawn(async move { ank.delete_workload("workload_Test".to_owned()).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
-        let response = generate_test_response_update_state_success(request.get_id());
+        let response = generate_test_response_update_state_success(request.request_id.clone());
 
         // Send the response
         response_sender.send(response).await.unwrap();
@@ -2178,19 +2302,17 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .withf(
-                |request: &UpdateStateRequest| match &request.request.request_content {
-                    Some(RequestContent::UpdateStateRequest(content)) => {
-                        content.update_mask == vec![format!("{WORKLOADS_PREFIX}.workload_Test")]
-                    }
-                    _ => false,
-                },
-            )
-            .return_once(|request: UpdateStateRequest| {
+            .withf(|request: &AnkaiosRequest| match &request.request_content {
+                Some(RequestContent::UpdateStateRequest(content)) => {
+                    content.update_mask == vec![format!("{WORKLOADS_PREFIX}.workload_Test")]
+                }
+                _ => false,
+            })
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2202,13 +2324,13 @@ mod tests {
         let method_handle =
             tokio::spawn(async move { ank.delete_workload("workload_Test".to_owned()).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let response = Response {
             content: super::ResponseType::Error("test".to_owned()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -2227,19 +2349,17 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .withf(
-                |request: &UpdateStateRequest| match &request.request.request_content {
-                    Some(RequestContent::UpdateStateRequest(content)) => {
-                        content.update_mask == vec![format!("{WORKLOADS_PREFIX}.workload_Test")]
-                    }
-                    _ => false,
-                },
-            )
-            .return_once(|request: UpdateStateRequest| {
+            .withf(|request: &AnkaiosRequest| match &request.request_content {
+                Some(RequestContent::UpdateStateRequest(content)) => {
+                    content.update_mask == vec![format!("{WORKLOADS_PREFIX}.workload_Test")]
+                }
+                _ => false,
+            })
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2251,13 +2371,13 @@ mod tests {
         let method_handle =
             tokio::spawn(async move { ank.delete_workload("workload_Test".to_owned()).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let response = Response {
             content: super::ResponseType::CompleteState(Box::default()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -2276,19 +2396,17 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .withf(
-                |request: &UpdateStateRequest| match &request.request.request_content {
-                    Some(RequestContent::UpdateStateRequest(content)) => {
-                        content.update_mask == vec![CONFIGS_PREFIX.to_owned()]
-                    }
-                    _ => false,
-                },
-            )
-            .return_once(|request: UpdateStateRequest| {
+            .withf(|request: &AnkaiosRequest| match &request.request_content {
+                Some(RequestContent::UpdateStateRequest(content)) => {
+                    content.update_mask == vec![CONFIGS_PREFIX.to_owned()]
+                }
+                _ => false,
+            })
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2302,11 +2420,11 @@ mod tests {
         // Prepare handle for updating the configs
         let method_handle = tokio::spawn(async move { ank.update_configs(configs).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
-        let response = generate_test_response_update_state_success(request.get_id());
+        let response = generate_test_response_update_state_success(request.request_id.clone());
 
         // Send the response
         response_sender.send(response).await.unwrap();
@@ -2324,19 +2442,17 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .withf(
-                |request: &UpdateStateRequest| match &request.request.request_content {
-                    Some(RequestContent::UpdateStateRequest(content)) => {
-                        content.update_mask == vec![CONFIGS_PREFIX.to_owned()]
-                    }
-                    _ => false,
-                },
-            )
-            .return_once(|request: UpdateStateRequest| {
+            .withf(|request: &AnkaiosRequest| match &request.request_content {
+                Some(RequestContent::UpdateStateRequest(content)) => {
+                    content.update_mask == vec![CONFIGS_PREFIX.to_owned()]
+                }
+                _ => false,
+            })
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2350,13 +2466,13 @@ mod tests {
         // Prepare handle for updating the configs
         let method_handle = tokio::spawn(async move { ank.update_configs(configs).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let response = Response {
             content: super::ResponseType::Error("test".to_owned()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -2375,19 +2491,17 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .withf(
-                |request: &UpdateStateRequest| match &request.request.request_content {
-                    Some(RequestContent::UpdateStateRequest(content)) => {
-                        content.update_mask == vec![CONFIGS_PREFIX.to_owned()]
-                    }
-                    _ => false,
-                },
-            )
-            .return_once(|request: UpdateStateRequest| {
+            .withf(|request: &AnkaiosRequest| match &request.request_content {
+                Some(RequestContent::UpdateStateRequest(content)) => {
+                    content.update_mask == vec![CONFIGS_PREFIX.to_owned()]
+                }
+                _ => false,
+            })
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2401,13 +2515,13 @@ mod tests {
         // Prepare handle for updating the configs
         let method_handle = tokio::spawn(async move { ank.update_configs(configs).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let response = Response {
             content: super::ResponseType::CompleteState(Box::default()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -2426,19 +2540,17 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .withf(
-                |request: &UpdateStateRequest| match &request.request.request_content {
-                    Some(RequestContent::UpdateStateRequest(content)) => {
-                        content.update_mask == vec![format!("{CONFIGS_PREFIX}.Test")]
-                    }
-                    _ => false,
-                },
-            )
-            .return_once(|request: UpdateStateRequest| {
+            .withf(|request: &AnkaiosRequest| match &request.request_content {
+                Some(RequestContent::UpdateStateRequest(content)) => {
+                    content.update_mask == vec![format!("{CONFIGS_PREFIX}.Test")]
+                }
+                _ => false,
+            })
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2453,11 +2565,11 @@ mod tests {
         let method_handle =
             tokio::spawn(async move { ank.add_config("Test".to_owned(), config).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
-        let response = generate_test_response_update_state_success(request.get_id());
+        let response = generate_test_response_update_state_success(request.request_id.clone());
 
         // Send the response
         response_sender.send(response).await.unwrap();
@@ -2475,19 +2587,17 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .withf(
-                |request: &UpdateStateRequest| match &request.request.request_content {
-                    Some(RequestContent::UpdateStateRequest(content)) => {
-                        content.update_mask == vec![format!("{CONFIGS_PREFIX}.Test")]
-                    }
-                    _ => false,
-                },
-            )
-            .return_once(|request: UpdateStateRequest| {
+            .withf(|request: &AnkaiosRequest| match &request.request_content {
+                Some(RequestContent::UpdateStateRequest(content)) => {
+                    content.update_mask == vec![format!("{CONFIGS_PREFIX}.Test")]
+                }
+                _ => false,
+            })
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2502,13 +2612,13 @@ mod tests {
         let method_handle =
             tokio::spawn(async move { ank.add_config("Test".to_owned(), config).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let response = Response {
             content: super::ResponseType::Error("test".to_owned()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -2527,19 +2637,17 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .withf(
-                |request: &UpdateStateRequest| match &request.request.request_content {
-                    Some(RequestContent::UpdateStateRequest(content)) => {
-                        content.update_mask == vec![format!("{CONFIGS_PREFIX}.Test")]
-                    }
-                    _ => false,
-                },
-            )
-            .return_once(|request: UpdateStateRequest| {
+            .withf(|request: &AnkaiosRequest| match &request.request_content {
+                Some(RequestContent::UpdateStateRequest(content)) => {
+                    content.update_mask == vec![format!("{CONFIGS_PREFIX}.Test")]
+                }
+                _ => false,
+            })
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2554,13 +2662,13 @@ mod tests {
         let method_handle =
             tokio::spawn(async move { ank.add_config("Test".to_owned(), config).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let response = Response {
             content: super::ResponseType::CompleteState(Box::default()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -2579,19 +2687,19 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &GetStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::CompleteStateRequest(content)) => {
                         content.field_mask == vec![CONFIGS_PREFIX]
                     }
                     _ => false,
                 },
             )
-            .return_once(move |request: GetStateRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2602,7 +2710,7 @@ mod tests {
         // Prepare handle for getting the configs
         let method_handle = tokio::spawn(async move { ank.get_configs().await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
@@ -2610,7 +2718,7 @@ mod tests {
         let complete_state = CompleteState::new_from_configs(configs.clone());
         let response = Response {
             content: super::ResponseType::CompleteState(Box::new(complete_state.clone())),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -2629,19 +2737,19 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &GetStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::CompleteStateRequest(content)) => {
                         content.field_mask == vec![format!("{CONFIGS_PREFIX}.Test")]
                     }
                     _ => false,
                 },
             )
-            .return_once(move |request: GetStateRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2652,7 +2760,7 @@ mod tests {
         // Prepare handle for getting the configs
         let method_handle = tokio::spawn(async move { ank.get_config("Test".to_owned()).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
@@ -2663,7 +2771,7 @@ mod tests {
         let complete_state = CompleteState::new_from_configs(configs.clone());
         let response = Response {
             content: super::ResponseType::CompleteState(Box::new(complete_state.clone())),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -2682,19 +2790,17 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .withf(
-                |request: &UpdateStateRequest| match &request.request.request_content {
-                    Some(RequestContent::UpdateStateRequest(content)) => {
-                        content.update_mask == vec![CONFIGS_PREFIX]
-                    }
-                    _ => false,
-                },
-            )
-            .return_once(|request: UpdateStateRequest| {
+            .withf(|request: &AnkaiosRequest| match &request.request_content {
+                Some(RequestContent::UpdateStateRequest(content)) => {
+                    content.update_mask == vec![CONFIGS_PREFIX]
+                }
+                _ => false,
+            })
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2705,11 +2811,11 @@ mod tests {
         // Prepare handle for deleting the workload
         let method_handle = tokio::spawn(async move { ank.delete_all_configs().await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
-        let response = generate_test_response_update_state_success(request.get_id());
+        let response = generate_test_response_update_state_success(request.request_id.clone());
 
         // Send the response
         response_sender.send(response).await.unwrap();
@@ -2725,19 +2831,17 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .withf(
-                |request: &UpdateStateRequest| match &request.request.request_content {
-                    Some(RequestContent::UpdateStateRequest(content)) => {
-                        content.update_mask == vec![CONFIGS_PREFIX]
-                    }
-                    _ => false,
-                },
-            )
-            .return_once(|request: UpdateStateRequest| {
+            .withf(|request: &AnkaiosRequest| match &request.request_content {
+                Some(RequestContent::UpdateStateRequest(content)) => {
+                    content.update_mask == vec![CONFIGS_PREFIX]
+                }
+                _ => false,
+            })
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2748,13 +2852,13 @@ mod tests {
         // Prepare handle for deleting the workload
         let method_handle = tokio::spawn(async move { ank.delete_all_configs().await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let response = Response {
             content: super::ResponseType::Error("test".to_owned()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -2773,19 +2877,17 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .withf(
-                |request: &UpdateStateRequest| match &request.request.request_content {
-                    Some(RequestContent::UpdateStateRequest(content)) => {
-                        content.update_mask == vec![CONFIGS_PREFIX]
-                    }
-                    _ => false,
-                },
-            )
-            .return_once(|request: UpdateStateRequest| {
+            .withf(|request: &AnkaiosRequest| match &request.request_content {
+                Some(RequestContent::UpdateStateRequest(content)) => {
+                    content.update_mask == vec![CONFIGS_PREFIX]
+                }
+                _ => false,
+            })
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2796,13 +2898,13 @@ mod tests {
         // Prepare handle for deleting the workload
         let method_handle = tokio::spawn(async move { ank.delete_all_configs().await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let response = Response {
             content: super::ResponseType::CompleteState(Box::default()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -2821,19 +2923,17 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .withf(
-                |request: &UpdateStateRequest| match &request.request.request_content {
-                    Some(RequestContent::UpdateStateRequest(content)) => {
-                        content.update_mask == vec![format!("{CONFIGS_PREFIX}.Test")]
-                    }
-                    _ => false,
-                },
-            )
-            .return_once(|request: UpdateStateRequest| {
+            .withf(|request: &AnkaiosRequest| match &request.request_content {
+                Some(RequestContent::UpdateStateRequest(content)) => {
+                    content.update_mask == vec![format!("{CONFIGS_PREFIX}.Test")]
+                }
+                _ => false,
+            })
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2844,11 +2944,11 @@ mod tests {
         // Prepare handle for deleting a config
         let method_handle = tokio::spawn(async move { ank.delete_config("Test".to_owned()).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
-        let response = generate_test_response_update_state_success(request.get_id());
+        let response = generate_test_response_update_state_success(request.request_id.clone());
 
         // Send the response
         response_sender.send(response).await.unwrap();
@@ -2864,19 +2964,17 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .withf(
-                |request: &UpdateStateRequest| match &request.request.request_content {
-                    Some(RequestContent::UpdateStateRequest(content)) => {
-                        content.update_mask == vec![format!("{CONFIGS_PREFIX}.Test")]
-                    }
-                    _ => false,
-                },
-            )
-            .return_once(|request: UpdateStateRequest| {
+            .withf(|request: &AnkaiosRequest| match &request.request_content {
+                Some(RequestContent::UpdateStateRequest(content)) => {
+                    content.update_mask == vec![format!("{CONFIGS_PREFIX}.Test")]
+                }
+                _ => false,
+            })
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2887,13 +2985,13 @@ mod tests {
         // Prepare handle for deleting a config
         let method_handle = tokio::spawn(async move { ank.delete_config("Test".to_owned()).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let response = Response {
             content: super::ResponseType::Error("test".to_owned()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -2912,19 +3010,17 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .withf(
-                |request: &UpdateStateRequest| match &request.request.request_content {
-                    Some(RequestContent::UpdateStateRequest(content)) => {
-                        content.update_mask == vec![format!("{CONFIGS_PREFIX}.Test")]
-                    }
-                    _ => false,
-                },
-            )
-            .return_once(|request: UpdateStateRequest| {
+            .withf(|request: &AnkaiosRequest| match &request.request_content {
+                Some(RequestContent::UpdateStateRequest(content)) => {
+                    content.update_mask == vec![format!("{CONFIGS_PREFIX}.Test")]
+                }
+                _ => false,
+            })
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -2935,13 +3031,13 @@ mod tests {
         // Prepare handle for deleting a config
         let method_handle = tokio::spawn(async move { ank.delete_config("Test".to_owned()).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let response = Response {
             content: super::ResponseType::CompleteState(Box::default()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -2960,34 +3056,32 @@ mod tests {
         // Prepare channel to intercept the request
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .withf(
-                |request: &UpdateStateRequest| match &request.request.request_content {
-                    Some(RequestContent::UpdateStateRequest(content)) => {
-                        content.update_mask == vec![format!("{AGENTS_PREFIX}.agent_A.tags")]
-                            && content.new_state.as_ref().is_some_and(|state| {
-                                state.agents.as_ref().is_some_and(|agents| {
-                                    agents.agents.get("agent_A").is_some_and(|agent| {
-                                        agent.tags.as_ref().is_some_and(|tags| {
-                                            tags.tags
-                                                .get("environment")
-                                                .is_some_and(|v| v == "production")
-                                                && tags
-                                                    .tags
-                                                    .get("region")
-                                                    .is_some_and(|v| v == "us-west")
-                                        })
+            .withf(|request: &AnkaiosRequest| match &request.request_content {
+                Some(RequestContent::UpdateStateRequest(content)) => {
+                    content.update_mask == vec![format!("{AGENTS_PREFIX}.agent_A.tags")]
+                        && content.new_state.as_ref().is_some_and(|state| {
+                            state.agents.as_ref().is_some_and(|agents| {
+                                agents.agents.get("agent_A").is_some_and(|agent| {
+                                    agent.tags.as_ref().is_some_and(|tags| {
+                                        tags.tags
+                                            .get("environment")
+                                            .is_some_and(|v| v == "production")
+                                            && tags
+                                                .tags
+                                                .get("region")
+                                                .is_some_and(|v| v == "us-west")
                                     })
                                 })
                             })
-                    }
-                    _ => false,
-                },
-            )
-            .return_once(|request: UpdateStateRequest| {
+                        })
+                }
+                _ => false,
+            })
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -3005,11 +3099,11 @@ mod tests {
         let method_handle =
             tokio::spawn(async move { ank.set_agent_tags("agent_A".to_owned(), tags).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
-        let response = generate_test_response_update_state_success(request.get_id());
+        let response = generate_test_response_update_state_success(request.request_id.clone());
 
         // Send the response
         response_sender.send(response).await.unwrap();
@@ -3025,19 +3119,17 @@ mod tests {
         // Prepare channel to intercept the request
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .withf(
-                |request: &UpdateStateRequest| match &request.request.request_content {
-                    Some(RequestContent::UpdateStateRequest(content)) => {
-                        content.update_mask == vec![format!("{AGENTS_PREFIX}.agent_A.tags")]
-                    }
-                    _ => false,
-                },
-            )
-            .return_once(|request: UpdateStateRequest| {
+            .withf(|request: &AnkaiosRequest| match &request.request_content {
+                Some(RequestContent::UpdateStateRequest(content)) => {
+                    content.update_mask == vec![format!("{AGENTS_PREFIX}.agent_A.tags")]
+                }
+                _ => false,
+            })
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -3055,13 +3147,13 @@ mod tests {
         let method_handle =
             tokio::spawn(async move { ank.set_agent_tags("agent_A".to_owned(), tags).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate an error response
         let response = Response {
             content: super::ResponseType::Error("test error".to_owned()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -3080,19 +3172,17 @@ mod tests {
         // Prepare channel to intercept the request
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .withf(
-                |request: &UpdateStateRequest| match &request.request.request_content {
-                    Some(RequestContent::UpdateStateRequest(content)) => {
-                        content.update_mask == vec![format!("{AGENTS_PREFIX}.agent_A.tags")]
-                    }
-                    _ => false,
-                },
-            )
-            .return_once(|request: UpdateStateRequest| {
+            .withf(|request: &AnkaiosRequest| match &request.request_content {
+                Some(RequestContent::UpdateStateRequest(content)) => {
+                    content.update_mask == vec![format!("{AGENTS_PREFIX}.agent_A.tags")]
+                }
+                _ => false,
+            })
+            .return_once(|request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -3110,13 +3200,13 @@ mod tests {
         let method_handle =
             tokio::spawn(async move { ank.set_agent_tags("agent_A".to_owned(), tags).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response with wrong type
         let response = Response {
             content: super::ResponseType::CompleteState(Box::default()),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -3135,19 +3225,19 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &GetStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::CompleteStateRequest(content)) => {
                         content.field_mask == vec![AGENTS_PREFIX]
                     }
                     _ => false,
                 },
             )
-            .return_once(move |request: GetStateRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -3158,14 +3248,14 @@ mod tests {
         // Prepare handle for getting the agents
         let method_handle = tokio::spawn(async move { ank.get_agents().await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let complete_state = CompleteState::new_from_proto(generate_complete_state_proto());
         let response = Response {
             content: super::ResponseType::CompleteState(Box::new(complete_state.clone())),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -3195,19 +3285,19 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &GetStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::CompleteStateRequest(content)) => {
                         content.field_mask == vec![format!("{AGENTS_PREFIX}.agent_A")]
                     }
                     _ => false,
                 },
             )
-            .return_once(move |request: GetStateRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -3219,14 +3309,14 @@ mod tests {
         let method_handle =
             tokio::spawn(async move { ank.get_agent(String::from("agent_A")).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let complete_state = CompleteState::new_from_proto(generate_complete_state_proto());
         let response = Response {
             content: super::ResponseType::CompleteState(Box::new(complete_state.clone())),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -3253,19 +3343,19 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &GetStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::CompleteStateRequest(content)) => {
                         content.field_mask == vec![format!("{AGENTS_PREFIX}.agent_not_there")]
                     }
                     _ => false,
                 },
             )
-            .return_once(move |request: GetStateRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -3277,14 +3367,14 @@ mod tests {
         let method_handle =
             tokio::spawn(async move { ank.get_agent(String::from("agent_not_there")).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let complete_state = CompleteState::new_from_proto(generate_complete_state_proto());
         let response = Response {
             content: super::ResponseType::CompleteState(Box::new(complete_state.clone())),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -3303,19 +3393,19 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &GetStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::CompleteStateRequest(content)) => {
                         content.field_mask == vec![WORKLOAD_STATES_PREFIX]
                     }
                     _ => false,
                 },
             )
-            .return_once(move |request: GetStateRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -3326,14 +3416,14 @@ mod tests {
         // Prepare handle for getting the workload states
         let method_handle = tokio::spawn(async move { ank.get_workload_states().await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let complete_state = CompleteState::new_from_proto(generate_complete_state_proto());
         let response = Response {
             content: super::ResponseType::CompleteState(Box::new(complete_state.clone())),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -3360,19 +3450,19 @@ mod tests {
         );
         let masks = vec![wl_instance_name.get_filter_mask()];
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &GetStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::CompleteStateRequest(content)) => {
                         content.field_mask == masks
                     }
                     _ => false,
                 },
             )
-            .return_once(move |request: GetStateRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -3386,14 +3476,14 @@ mod tests {
                 .await
         });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let complete_state = CompleteState::new_from_proto(generate_complete_state_proto());
         let response = Response {
             content: super::ResponseType::CompleteState(Box::new(complete_state.clone())),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -3415,19 +3505,19 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &GetStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::CompleteStateRequest(content)) => {
                         content.field_mask == vec![format!("{WORKLOAD_STATES_PREFIX}.agent_A")]
                     }
                     _ => false,
                 },
             )
-            .return_once(move |request: GetStateRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -3441,14 +3531,14 @@ mod tests {
                 async move { ank.get_workload_states_on_agent("agent_A".to_owned()).await },
             );
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let complete_state = CompleteState::new_from_proto(generate_complete_state_proto());
         let response = Response {
             content: super::ResponseType::CompleteState(Box::new(complete_state.clone())),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -3467,19 +3557,19 @@ mod tests {
         // Prepare channel to intercept the request that is being
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &GetStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::CompleteStateRequest(content)) => {
                         content.field_mask == vec![format!("{WORKLOAD_STATES_PREFIX}")]
                     }
                     _ => false,
                 },
             )
-            .return_once(move |request: GetStateRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -3491,14 +3581,14 @@ mod tests {
         let method_handle =
             tokio::spawn(async move { ank.get_workload_states_for_name("nginx".to_owned()).await });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let complete_state = CompleteState::new_from_proto(generate_complete_state_proto());
         let response = Response {
             content: super::ResponseType::CompleteState(Box::new(complete_state.clone())),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -3525,19 +3615,19 @@ mod tests {
         );
         let masks = vec![wl_instance_name.get_filter_mask()];
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .withf(
-                move |request: &GetStateRequest| match &request.request.request_content {
+                move |request: &AnkaiosRequest| match &request.request_content {
                     Some(RequestContent::CompleteStateRequest(content)) => {
                         content.field_mask == masks
                     }
                     _ => false,
                 },
             )
-            .return_once(move |request: GetStateRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -3551,14 +3641,14 @@ mod tests {
                 .await
         });
 
-        // Get the request from the ControlInterface
+        // Get the request from the Connection
         let request = request_receiver.await.unwrap();
 
         // Fabricate a response
         let complete_state = CompleteState::new_from_proto(generate_complete_state_proto());
         let response = Response {
             content: super::ResponseType::CompleteState(Box::new(complete_state.clone())),
-            id: request.get_id(),
+            id: request.request_id.clone(),
         };
 
         // Send the response
@@ -3584,12 +3674,12 @@ mod tests {
         );
 
         let mut call_sequence = mockall::Sequence::new();
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .in_sequence(&mut call_sequence)
-            .return_once(move |request: AnkaiosLogsRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -3630,14 +3720,14 @@ mod tests {
         let request = request_receiver.await.unwrap();
 
         let logs_accept_requested = Response {
-            id: request.get_id(),
+            id: request.request_id.clone(),
             content: super::ResponseType::LogsRequestAccepted(vec![instance_name.clone()]),
         };
 
         assert!(response_sender.send(logs_accept_requested).await.is_ok());
 
         let logs_entries_response = Response {
-            id: request.get_id(),
+            id: request.request_id.clone(),
             content: super::ResponseType::LogEntriesResponse(log_entries.clone()),
         };
 
@@ -3668,11 +3758,11 @@ mod tests {
             "1234".to_owned(),
         );
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .return_once(move |request: AnkaiosLogsRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -3693,7 +3783,7 @@ mod tests {
         let request = request_receiver.await.unwrap();
 
         let response_error = Response {
-            id: request.get_id(),
+            id: request.request_id.clone(),
             content: super::ResponseType::Error("connection interruption".to_owned()),
         };
 
@@ -3719,11 +3809,11 @@ mod tests {
             "1234".to_owned(),
         );
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .return_once(move |request: AnkaiosLogsRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -3744,7 +3834,7 @@ mod tests {
         let request = request_receiver.await.unwrap();
 
         let response_error = Response {
-            id: request.get_id(),
+            id: request.request_id.clone(),
             content: super::ResponseType::UpdateStateSuccess(Box::default()),
         };
 
@@ -3770,11 +3860,11 @@ mod tests {
             "1234".to_owned(),
         );
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .return_once(move |request: LogsCancelRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -3802,7 +3892,7 @@ mod tests {
         let request = request_receiver.await.unwrap();
 
         let logs_cancel_accepted = Response {
-            id: request.get_id(),
+            id: request.request_id.clone(),
             content: super::ResponseType::LogsCancelAccepted,
         };
 
@@ -3826,11 +3916,11 @@ mod tests {
             "1234".to_owned(),
         );
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .return_once(move |request: LogsCancelRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -3858,7 +3948,7 @@ mod tests {
         let request = request_receiver.await.unwrap();
 
         let response_error = Response {
-            id: request.get_id(),
+            id: request.request_id.clone(),
             content: super::ResponseType::Error("failed to cancel logs".to_owned()),
         };
 
@@ -3886,11 +3976,11 @@ mod tests {
             "1234".to_owned(),
         );
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .return_once(move |request: LogsCancelRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -3918,7 +4008,7 @@ mod tests {
         let request = request_receiver.await.unwrap();
 
         let response_error = Response {
-            id: request.get_id(),
+            id: request.request_id.clone(),
             content: super::ResponseType::UpdateStateSuccess(Box::default()),
         };
 
@@ -3941,12 +4031,12 @@ mod tests {
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
         let mut call_sequence = mockall::Sequence::new();
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
             .in_sequence(&mut call_sequence)
-            .return_once(move |request: EventsRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -3980,14 +4070,14 @@ mod tests {
         let request = request_receiver.await.unwrap();
 
         let events_accept_requested = Response {
-            id: request.get_id(),
+            id: request.request_id.clone(),
             content: super::ResponseType::CompleteState(Box::default()),
         };
 
         assert!(response_sender.send(events_accept_requested).await.is_ok());
 
         let events_entry_response = Response {
-            id: request.get_id(),
+            id: request.request_id.clone(),
             content: super::ResponseType::EventResponse(Box::new(event_entry.clone())),
         };
 
@@ -4011,11 +4101,11 @@ mod tests {
 
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .return_once(move |request: EventsRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -4032,7 +4122,7 @@ mod tests {
         let request = request_receiver.await.unwrap();
 
         let response_error = Response {
-            id: request.get_id(),
+            id: request.request_id.clone(),
             content: super::ResponseType::Error("connection interruption".to_owned()),
         };
 
@@ -4052,11 +4142,11 @@ mod tests {
 
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .return_once(move |request: EventsRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -4073,7 +4163,7 @@ mod tests {
         let request = request_receiver.await.unwrap();
 
         let response_error = Response {
-            id: request.get_id(),
+            id: request.request_id.clone(),
             content: super::ResponseType::UpdateStateSuccess(Box::default()),
         };
 
@@ -4093,11 +4183,11 @@ mod tests {
 
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .return_once(move |request: EventsCancelRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -4121,7 +4211,7 @@ mod tests {
         let request = request_receiver.await.unwrap();
 
         let events_cancel_accepted = Response {
-            id: request.get_id(),
+            id: request.request_id.clone(),
             content: super::ResponseType::EventsCancelAccepted,
         };
 
@@ -4139,11 +4229,11 @@ mod tests {
 
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .return_once(move |request: EventsCancelRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -4167,7 +4257,7 @@ mod tests {
         let request = request_receiver.await.unwrap();
 
         let response_error = Response {
-            id: request.get_id(),
+            id: request.request_id.clone(),
             content: super::ResponseType::Error("failed to unregister".to_owned()),
         };
 
@@ -4189,11 +4279,11 @@ mod tests {
 
         let (request_sender, request_receiver) = tokio::sync::oneshot::channel();
 
-        let mut ci_mock = ControlInterface::default();
+        let mut ci_mock = MockConnection::default();
         ci_mock
             .expect_write_request()
             .times(1)
-            .return_once(move |request: EventsCancelRequest| {
+            .return_once(move |request: AnkaiosRequest| {
                 request_sender.send(request).unwrap();
                 Ok(())
             });
@@ -4217,7 +4307,7 @@ mod tests {
         let request = request_receiver.await.unwrap();
 
         let response_error = Response {
-            id: request.get_id(),
+            id: request.request_id.clone(),
             content: super::ResponseType::UpdateStateSuccess(Box::default()),
         };
 

--- a/src/ankaios_api/mod.rs
+++ b/src/ankaios_api/mod.rs
@@ -27,7 +27,7 @@ pub mod control_api {
     tonic::include_proto!("control_api");
 }
 
-#[cfg(feature = "grpc_server_interface")]
+#[cfg(feature = "command_interface")]
 pub mod grpc_api {
     tonic::include_proto!("grpc_api");
 }

--- a/src/ankaios_api/mod.rs
+++ b/src/ankaios_api/mod.rs
@@ -22,8 +22,14 @@
     clippy::shadow_reuse
 )]
 
+#[cfg(feature = "control_interface")]
 pub mod control_api {
     tonic::include_proto!("control_api");
+}
+
+#[cfg(feature = "grpc_server_interface")]
+pub mod grpc_api {
+    tonic::include_proto!("grpc_api");
 }
 
 pub mod ank_base;

--- a/src/components/connection.rs
+++ b/src/components/connection.rs
@@ -16,7 +16,7 @@
 //! SDK can connect to [Ankaios] through: the Control Interface (Unix FIFO pipes an agent mounts
 //! into a workload's own container, for use from inside that workload; behind the
 //! `control_interface` feature) and the Command Interface (a direct gRPC connection to the
-//! Ankaios server, for use from outside the cluster; behind the `grpc_server_interface` feature).
+//! Ankaios server, for use from outside the cluster; behind the `command_interface` feature).
 //!
 //! [Ankaios]: https://eclipse-ankaios.github.io/ankaios
 
@@ -31,10 +31,10 @@ use crate::ankaios_api::ank_base::Request as AnkaiosRequest;
 use crate::components::event_types::EventEntry;
 use crate::components::log_types::LogResponse;
 
+#[cfg(feature = "command_interface")]
+pub mod command_interface;
 #[cfg(feature = "control_interface")]
 pub mod control_interface;
-#[cfg(feature = "grpc_server_interface")]
-pub mod grpc_interface;
 mod helpers;
 
 pub(crate) use helpers::{
@@ -43,13 +43,13 @@ pub(crate) use helpers::{
 };
 
 /// Version of [Ankaios](https://eclipse-ankaios.github.io/ankaios) that is compatible with this
-/// SDK, sent as part of every connection handshake (control interface or gRPC), regardless of
-/// transport.
+/// SDK, sent as part of every connection handshake (control interface or command interface),
+/// regardless of transport.
 pub(crate) const ANKAIOS_VERSION: &str = "1.0.0";
 
 /// Abstracts over the transport used to exchange [`AnkaiosRequest`]/[`Response`](crate::Response)
 /// messages with Ankaios, so that [`Ankaios`](crate::Ankaios) can work identically regardless of
-/// whether it is connected via the control interface or via gRPC.
+/// whether it is connected via the control interface or the command interface.
 #[cfg_attr(test, automock)]
 #[async_trait]
 pub(crate) trait Connection: Send {

--- a/src/components/connection.rs
+++ b/src/components/connection.rs
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Elektrobit Automotive GmbH
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module contains the [`Connection`] trait, implemented by the different interfaces the
+//! SDK can connect to [Ankaios] through: the Control Interface (Unix FIFO pipes an agent mounts
+//! into a workload's own container, for use from inside that workload; behind the
+//! `control_interface` feature) and the Command Interface (a direct gRPC connection to the
+//! Ankaios server, for use from outside the cluster; behind the `grpc_server_interface` feature).
+//!
+//! [Ankaios]: https://eclipse-ankaios.github.io/ankaios
+
+use async_trait::async_trait;
+#[cfg(test)]
+use mockall::automock;
+use tokio::sync::mpsc;
+use tokio::time::Duration;
+
+use crate::AnkaiosError;
+use crate::ankaios_api::ank_base::Request as AnkaiosRequest;
+use crate::components::event_types::EventEntry;
+use crate::components::log_types::LogResponse;
+
+#[cfg(feature = "control_interface")]
+pub mod control_interface;
+#[cfg(feature = "grpc_server_interface")]
+pub mod grpc_interface;
+mod helpers;
+
+pub(crate) use helpers::{
+    RequestId, SynchronizedSenderMap, forward_event_response, forward_log_entries,
+    forward_logs_stop_response,
+};
+
+/// Version of [Ankaios](https://eclipse-ankaios.github.io/ankaios) that is compatible with this
+/// SDK, sent as part of every connection handshake (control interface or gRPC), regardless of
+/// transport.
+pub(crate) const ANKAIOS_VERSION: &str = "1.0.0";
+
+/// Abstracts over the transport used to exchange [`AnkaiosRequest`]/[`Response`](crate::Response)
+/// messages with Ankaios, so that [`Ankaios`](crate::Ankaios) can work identically regardless of
+/// whether it is connected via the control interface or via gRPC.
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub(crate) trait Connection: Send {
+    /// Establishes the connection, waiting up to `timeout` for it to be accepted.
+    async fn connect(&mut self, timeout: Duration) -> Result<(), AnkaiosError>;
+
+    /// Tears down the connection.
+    fn disconnect(&mut self) -> Result<(), AnkaiosError>;
+
+    /// Sends a request. The request must already have been converted to its proto
+    /// representation via [`Request::to_proto`](crate::Request::to_proto).
+    async fn write_request(&mut self, request: AnkaiosRequest) -> Result<(), AnkaiosError>;
+
+    /// Registers a channel to receive log entries for an ongoing log campaign.
+    fn add_log_campaign(&mut self, request_id: RequestId, logs_sender: mpsc::Sender<LogResponse>);
+
+    /// Unregisters a log campaign started via [`add_log_campaign`](Connection::add_log_campaign).
+    fn remove_log_campaign(&mut self, request_id: &str);
+
+    /// Registers a channel to receive events for an ongoing event campaign.
+    fn add_events_campaign(
+        &mut self,
+        request_id: RequestId,
+        events_sender: mpsc::Sender<EventEntry>,
+    );
+
+    /// Unregisters an event campaign started via [`add_events_campaign`](Connection::add_events_campaign).
+    fn remove_events_campaign(&mut self, request_id: &str);
+}

--- a/src/components/connection/command_interface.rs
+++ b/src/components/connection/command_interface.rs
@@ -194,6 +194,67 @@ impl ReaderTransport for GrpcTransport {
     }
 }
 
+/// Reads from `transport` until the connection is closed or errors, forwarding every decoded
+/// message to [`CommandInterfaceConnection::handle_decoded_response`].
+async fn read_until_disconnected<T: ReaderTransport>(
+    transport: &mut T,
+    response_sender: &mpsc::Sender<Response>,
+    logs_sender_map: &mut SynchronizedSenderMap<LogResponse>,
+    events_sender_map: &mut SynchronizedSenderMap<EventEntry>,
+) {
+    loop {
+        match transport.next_message().await {
+            Ok(Some(from_server)) => {
+                CommandInterfaceConnection::handle_decoded_response(
+                    from_server,
+                    response_sender,
+                    logs_sender_map,
+                    events_sender_map,
+                )
+                .await;
+            }
+            Ok(None) => {
+                log::warn!("The connection to the Ankaios server was closed.");
+                return;
+            }
+            Err(status) => {
+                log::error!("Error while reading from the connection: '{status}'");
+                return;
+            }
+        }
+    }
+}
+
+/// Retries `transport.attempt_connect()` every [`RECONNECT_INTERVAL_MILLIS`] until it succeeds
+/// or `state` becomes [`CommandInterfaceState::Terminated`]. Returns `true` once reconnected
+/// (with `state` set back to [`CommandInterfaceState::Connected`]), or `false` if `disconnect()`
+/// won the race.
+async fn reconnect_until_connected_or_terminated<T: ReaderTransport>(
+    transport: &mut T,
+    state: &Arc<Mutex<CommandInterfaceState>>,
+    writer_ch_sender: &Arc<Mutex<Option<mpsc::Sender<ToServer>>>>,
+) -> bool {
+    loop {
+        sleep(Duration::from_millis(RECONNECT_INTERVAL_MILLIS)).await;
+        let sender = match transport.attempt_connect().await {
+            Ok(sender) => sender,
+            Err(err) => {
+                log::debug!("Reconnect attempt failed: '{err}'");
+                continue;
+            }
+        };
+
+        let mut state_guard = state.lock().unwrap_or_else(|_| unreachable!());
+        if *state_guard == CommandInterfaceState::Terminated {
+            return false; // disconnect() won; drop the new sender/stream.
+        }
+        *writer_ch_sender.lock().unwrap_or_else(|_| unreachable!()) = Some(sender);
+        *state_guard = CommandInterfaceState::Connected;
+        log::info!("Reconnected to the Ankaios server.");
+        return true;
+    }
+}
+
 /// Reads continuously from `transport`, reconnecting every [`RECONNECT_INTERVAL_MILLIS`] if the
 /// connection is lost, until `state` becomes [`CommandInterfaceState::Terminated`]. A free function
 /// so tests can call it directly instead of through [`tokio::spawn`].
@@ -205,34 +266,20 @@ async fn run_reader_loop<T: ReaderTransport>(
     mut logs_sender_map: SynchronizedSenderMap<LogResponse>,
     mut events_sender_map: SynchronizedSenderMap<EventEntry>,
 ) {
-    'connection: loop {
-        loop {
-            match transport.next_message().await {
-                Ok(Some(from_server)) => {
-                    CommandInterfaceConnection::handle_decoded_response(
-                        from_server,
-                        &response_sender,
-                        &mut logs_sender_map,
-                        &mut events_sender_map,
-                    )
-                    .await;
-                }
-                Ok(None) => {
-                    log::warn!("The connection to the Ankaios server was closed.");
-                    break;
-                }
-                Err(status) => {
-                    log::error!("Error while reading from the connection: '{status}'");
-                    break;
-                }
-            }
-        }
+    loop {
+        read_until_disconnected(
+            &mut transport,
+            &response_sender,
+            &mut logs_sender_map,
+            &mut events_sender_map,
+        )
+        .await;
 
         {
             let mut state_guard = state.lock().unwrap_or_else(|_| unreachable!());
             if *state_guard == CommandInterfaceState::Terminated {
                 // disconnect() was called; don't try to reconnect.
-                break 'connection;
+                return;
             }
             *state_guard = CommandInterfaceState::Reconnecting;
         }
@@ -240,23 +287,9 @@ async fn run_reader_loop<T: ReaderTransport>(
             "Lost connection to the Ankaios server, attempting to reconnect every {RECONNECT_INTERVAL_MILLIS}ms..."
         );
 
-        loop {
-            sleep(Duration::from_millis(RECONNECT_INTERVAL_MILLIS)).await;
-            match transport.attempt_connect().await {
-                Ok(sender) => {
-                    let mut state_guard = state.lock().unwrap_or_else(|_| unreachable!());
-                    if *state_guard == CommandInterfaceState::Terminated {
-                        break 'connection; // disconnect() won; drop the new sender/stream.
-                    }
-                    *writer_ch_sender.lock().unwrap_or_else(|_| unreachable!()) = Some(sender);
-                    *state_guard = CommandInterfaceState::Connected;
-                    log::info!("Reconnected to the Ankaios server.");
-                    break;
-                }
-                Err(err) => {
-                    log::debug!("Reconnect attempt failed: '{err}'");
-                }
-            }
+        if !reconnect_until_connected_or_terminated(&mut transport, &state, &writer_ch_sender).await
+        {
+            return; // disconnect() was called during reconnect attempts.
         }
     }
 }

--- a/src/components/connection/command_interface.rs
+++ b/src/components/connection/command_interface.rs
@@ -12,10 +12,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! This module contains the [`GrpcConfig`] struct and the gRPC implementation of the
-//! [`Connection`] trait, used to connect to an
-//! [Ankaios](https://eclipse-ankaios.github.io/ankaios) server directly over gRPC, e.g. from
-//! outside of the cluster.
+//! This module contains the [`CommandInterfaceConnection`] and [`GrpcConfig`] structs and the
+//! [`CommandInterfaceState`] enum, implementing the [`Connection`] trait over the
+//! [Ankaios](https://eclipse-ankaios.github.io/ankaios) command interface (a direct gRPC
+//! connection to the Ankaios server), used to connect to Ankaios from outside a workload.
 
 use async_trait::async_trait;
 #[cfg(test)]
@@ -39,11 +39,10 @@ use crate::components::log_types::LogResponse;
 use crate::components::response::{Response, ResponseType};
 
 /// Configuration for connecting to an [Ankaios](https://eclipse-ankaios.github.io/ankaios)
-/// server over gRPC.
+/// server over the command interface.
 ///
 /// Constructed either insecure (plaintext, via [`GrpcConfig::insecure`]) or mTLS-secured (via
-/// [`GrpcConfig::mtls`]) — the certificate material is mandatory context for a secured
-/// connection, not an optional add-on, so there is no default-then-upgrade path between the two.
+/// [`GrpcConfig::mtls`]) with the certificate material being mandatory context.
 ///
 /// ## Examples
 ///
@@ -120,10 +119,10 @@ impl std::fmt::Debug for GrpcConfig {
     }
 }
 
-/// Enum representing the state of the [`GrpcConnection`].
+/// Enum representing the state of the [`CommandInterfaceConnection`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(i32)]
-pub enum GrpcConnectionState {
+pub enum CommandInterfaceState {
     /// The connection was initialized but not yet accepted by the server.
     Initialized = 1,
     /// The connection is established.
@@ -139,19 +138,18 @@ pub enum GrpcConnectionState {
 const RECONNECT_INTERVAL_MILLIS: u64 = 500;
 
 /// This struct handles the interaction with an [Ankaios](https://eclipse-ankaios.github.io/ankaios)
-/// server over gRPC, playing the commander role via `CommandConnection.ConnectCommand`. The
-/// initial [`connect`](Connection::connect) attempt is never retried. Once a connection has
-/// been successfully established, losing it is treated as transient: the connection is rebuilt
-/// and retried every [`RECONNECT_INTERVAL_MILLIS`] until it succeeds.
-pub struct GrpcConnection {
+/// server over the command interface (a gRPC connection). Once a connection has been
+/// successfully established, losing it is treated as transient: the connection is rebuilt and
+/// retried every [`RECONNECT_INTERVAL_MILLIS`] until it succeeds.
+pub struct CommandInterfaceConnection {
     /// Configuration used to connect to the Ankaios server.
     config: GrpcConfig,
-    /// State of the gRPC connection.
-    state: Arc<Mutex<GrpcConnectionState>>,
-    /// Sender for the outgoing message stream fed into the gRPC bidi call. Shared with the
+    /// State of the command interface connection.
+    state: Arc<Mutex<CommandInterfaceState>>,
+    /// Sender for the outgoing message stream fed into the command interface bidi call. Shared with the
     /// reader/reconnect task, which replaces it whenever the connection is rebuilt.
     writer_ch_sender: Arc<Mutex<Option<mpsc::Sender<ToServer>>>>,
-    /// Handler for the task reading incoming messages from the gRPC bidi stream (and
+    /// Handler for the task reading incoming messages from the command interface bidi stream (and
     /// transparently reconnecting on a lost connection).
     reader_task_handle: Option<JoinHandle<()>>,
     /// Sender for the response channel.
@@ -169,7 +167,7 @@ pub struct GrpcConnection {
 trait ReaderTransport: Send {
     async fn next_message(&mut self) -> Result<Option<FromServer>, tonic::Status>;
 
-    /// Also used for the initial connect, not just reconnects.
+    /// Used for both the initial connection and the reconnect logic.
     async fn attempt_connect(&mut self) -> Result<mpsc::Sender<ToServer>, AnkaiosError>;
 }
 
@@ -190,18 +188,18 @@ impl ReaderTransport for GrpcTransport {
     }
 
     async fn attempt_connect(&mut self) -> Result<mpsc::Sender<ToServer>, AnkaiosError> {
-        let (sender, streaming) = GrpcConnection::open_stream(&self.config).await?;
+        let (sender, streaming) = CommandInterfaceConnection::open_stream(&self.config).await?;
         self.streaming = Some(streaming);
         Ok(sender)
     }
 }
 
 /// Reads continuously from `transport`, reconnecting every [`RECONNECT_INTERVAL_MILLIS`] if the
-/// connection is lost, until `state` becomes [`GrpcConnectionState::Terminated`]. A free function
+/// connection is lost, until `state` becomes [`CommandInterfaceState::Terminated`]. A free function
 /// so tests can call it directly instead of through [`tokio::spawn`].
 async fn run_reader_loop<T: ReaderTransport>(
     mut transport: T,
-    state: Arc<Mutex<GrpcConnectionState>>,
+    state: Arc<Mutex<CommandInterfaceState>>,
     writer_ch_sender: Arc<Mutex<Option<mpsc::Sender<ToServer>>>>,
     response_sender: mpsc::Sender<Response>,
     mut logs_sender_map: SynchronizedSenderMap<LogResponse>,
@@ -211,7 +209,7 @@ async fn run_reader_loop<T: ReaderTransport>(
         loop {
             match transport.next_message().await {
                 Ok(Some(from_server)) => {
-                    GrpcConnection::handle_decoded_response(
+                    CommandInterfaceConnection::handle_decoded_response(
                         from_server,
                         &response_sender,
                         &mut logs_sender_map,
@@ -220,11 +218,11 @@ async fn run_reader_loop<T: ReaderTransport>(
                     .await;
                 }
                 Ok(None) => {
-                    log::warn!("The gRPC connection to the Ankaios server was closed.");
+                    log::warn!("The connection to the Ankaios server was closed.");
                     break;
                 }
                 Err(status) => {
-                    log::error!("Error while reading from the gRPC connection: '{status}'");
+                    log::error!("Error while reading from the connection: '{status}'");
                     break;
                 }
             }
@@ -232,11 +230,11 @@ async fn run_reader_loop<T: ReaderTransport>(
 
         {
             let mut state_guard = state.lock().unwrap_or_else(|_| unreachable!());
-            if *state_guard == GrpcConnectionState::Terminated {
+            if *state_guard == CommandInterfaceState::Terminated {
                 // disconnect() was called; don't try to reconnect.
                 break 'connection;
             }
-            *state_guard = GrpcConnectionState::Reconnecting;
+            *state_guard = CommandInterfaceState::Reconnecting;
         }
         log::warn!(
             "Lost connection to the Ankaios server, attempting to reconnect every {RECONNECT_INTERVAL_MILLIS}ms..."
@@ -247,11 +245,11 @@ async fn run_reader_loop<T: ReaderTransport>(
             match transport.attempt_connect().await {
                 Ok(sender) => {
                     let mut state_guard = state.lock().unwrap_or_else(|_| unreachable!());
-                    if *state_guard == GrpcConnectionState::Terminated {
+                    if *state_guard == CommandInterfaceState::Terminated {
                         break 'connection; // disconnect() won; drop the new sender/stream.
                     }
                     *writer_ch_sender.lock().unwrap_or_else(|_| unreachable!()) = Some(sender);
-                    *state_guard = GrpcConnectionState::Connected;
+                    *state_guard = CommandInterfaceState::Connected;
                     log::info!("Reconnected to the Ankaios server.");
                     break;
                 }
@@ -263,8 +261,8 @@ async fn run_reader_loop<T: ReaderTransport>(
     }
 }
 
-impl GrpcConnection {
-    /// Creates a new instance of the gRPC connection.
+impl CommandInterfaceConnection {
+    /// Creates a new instance of the command interface connection.
     ///
     /// ## Arguments
     ///
@@ -273,11 +271,11 @@ impl GrpcConnection {
     ///
     /// ## Returns
     ///
-    /// A new [`GrpcConnection`] instance.
+    /// A new [`CommandInterfaceConnection`] instance.
     pub fn new(config: GrpcConfig, response_sender: mpsc::Sender<Response>) -> Self {
         Self {
             config,
-            state: Arc::new(Mutex::new(GrpcConnectionState::Terminated)),
+            state: Arc::new(Mutex::new(CommandInterfaceState::Terminated)),
             writer_ch_sender: Arc::new(Mutex::new(None)),
             reader_task_handle: None,
             response_sender,
@@ -323,8 +321,7 @@ impl GrpcConnection {
     }
 
     /// Builds the gRPC channel, sends the initial [`CommanderHello`] and opens the
-    /// `ConnectCommand` bidi stream. Used both for the initial connect and for every reconnect
-    /// attempt.
+    /// `ConnectCommand` bidi stream.
     async fn open_stream(
         config: &GrpcConfig,
     ) -> Result<(mpsc::Sender<ToServer>, tonic::Streaming<FromServer>), AnkaiosError> {
@@ -359,8 +356,7 @@ impl GrpcConnection {
     }
 
     /// Establishes the gRPC channel, sends the initial [`CommanderHello`], opens the
-    /// `ConnectCommand` bidi stream and spawns the task reading from it (which transparently
-    /// reconnects if the connection is later lost).
+    /// `ConnectCommand` bidi stream and spawns the task reading from it.
     async fn connect_internal(&mut self) -> Result<(), AnkaiosError> {
         let mut transport = GrpcTransport {
             config: self.config.clone(),
@@ -457,27 +453,27 @@ impl GrpcConnection {
 }
 
 #[async_trait]
-impl Connection for GrpcConnection {
+impl Connection for CommandInterfaceConnection {
     async fn connect(&mut self, timeout: Duration) -> Result<(), AnkaiosError> {
         {
             let mut state_guard = self.state.lock().unwrap_or_else(|_| unreachable!());
             if matches!(
                 *state_guard,
-                GrpcConnectionState::Initialized
-                    | GrpcConnectionState::Connected
-                    | GrpcConnectionState::Reconnecting
+                CommandInterfaceState::Initialized
+                    | CommandInterfaceState::Connected
+                    | CommandInterfaceState::Reconnecting
             ) {
                 return Err(AnkaiosError::ConnectionError(
                     "Already connected.".to_owned(),
                 ));
             }
-            *state_guard = GrpcConnectionState::Initialized;
+            *state_guard = CommandInterfaceState::Initialized;
         }
         match tokio_timeout(timeout, self.connect_internal()).await {
             Ok(Ok(())) => {
                 *self.state.lock().unwrap_or_else(|_| unreachable!()) =
-                    GrpcConnectionState::Connected;
-                log::trace!("Connected to the Ankaios server over gRPC.");
+                    CommandInterfaceState::Connected;
+                log::trace!("Connected to the Ankaios server over the command interface.");
                 Ok(())
             }
             Ok(Err(err)) => Err(err),
@@ -490,12 +486,12 @@ impl Connection for GrpcConnection {
     fn disconnect(&mut self) -> Result<(), AnkaiosError> {
         {
             let mut state_guard = self.state.lock().unwrap_or_else(|_| unreachable!());
-            if *state_guard == GrpcConnectionState::Terminated {
+            if *state_guard == CommandInterfaceState::Terminated {
                 return Err(AnkaiosError::ConnectionError(
                     "Already disconnected.".to_owned(),
                 ));
             }
-            *state_guard = GrpcConnectionState::Terminated;
+            *state_guard = CommandInterfaceState::Terminated;
         }
 
         if let Some(handler) = self.reader_task_handle.take() {
@@ -509,10 +505,11 @@ impl Connection for GrpcConnection {
     }
 
     async fn write_request(&mut self, request: AnkaiosRequest) -> Result<(), AnkaiosError> {
-        if *self.state.lock().unwrap_or_else(|_| unreachable!()) != GrpcConnectionState::Connected {
-            log::error!("Could not write to the gRPC connection, not connected.");
+        if *self.state.lock().unwrap_or_else(|_| unreachable!()) != CommandInterfaceState::Connected
+        {
+            log::error!("Could not write to the command interface, not connected.");
             return Err(AnkaiosError::ConnectionError(
-                "Could not write to the gRPC connection, not connected.".to_owned(),
+                "Could not write to the command interface, not connected.".to_owned(),
             ));
         }
         let maybe_sender = self
@@ -572,8 +569,9 @@ mod tests {
     use tokio::time::{Duration, sleep};
 
     use super::{
-        Connection, FromServer, FromServerEnum, GrpcConfig, GrpcConnection, GrpcConnectionState,
-        MockReaderTransport, SynchronizedSenderMap, ToServer, ToServerEnum, run_reader_loop,
+        CommandInterfaceConnection, CommandInterfaceState, Connection, FromServer, FromServerEnum,
+        GrpcConfig, MockReaderTransport, SynchronizedSenderMap, ToServer, ToServerEnum,
+        run_reader_loop,
     };
     use crate::ankaios_api::ank_base::{self, response::ResponseContent as AnkaiosResponseContent};
     use crate::components::request::{Request, generate_test_request};
@@ -586,10 +584,10 @@ mod tests {
     const REQUEST_ID: &str = "request_id_1";
     const CHANNEL_SIZE: usize = 10;
 
-    fn generate_test_grpc_connection() -> (GrpcConnection, mpsc::Receiver<Response>) {
+    fn generate_test_command_interface_connection() -> (CommandInterfaceConnection, mpsc::Receiver<Response>) {
         let (response_sender, response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
         (
-            GrpcConnection::new(GrpcConfig::insecure(SERVER_URL), response_sender),
+            CommandInterfaceConnection::new(GrpcConfig::insecure(SERVER_URL), response_sender),
             response_receiver,
         )
     }
@@ -627,42 +625,44 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn utest_grpc_connection_new_starts_terminated() {
-        let (connection, _response_receiver) = generate_test_grpc_connection();
+    async fn utest_command_interface_new_starts_terminated() {
+        let (connection, _response_receiver) = generate_test_command_interface_connection();
         assert_eq!(
             *connection.state.lock().unwrap(),
-            GrpcConnectionState::Terminated
+            CommandInterfaceState::Terminated
         );
     }
 
     #[tokio::test]
-    async fn utest_grpc_connection_connect_fails_on_unreachable_server() {
+    async fn utest_command_interface_connect_fails_on_unreachable_server() {
         let (response_sender, _response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
         // Port 0 is never a valid connection target, so this fails fast without needing a
         // real (or even reachable) Ankaios server.
-        let mut connection =
-            GrpcConnection::new(GrpcConfig::insecure("http://127.0.0.1:0"), response_sender);
+        let mut connection = CommandInterfaceConnection::new(
+            GrpcConfig::insecure("http://127.0.0.1:0"),
+            response_sender,
+        );
 
         let result = connection.connect(Duration::from_secs(5)).await;
         assert!(result.is_err());
         assert!(matches!(result, Err(AnkaiosError::ConnectionError(_))));
         assert_eq!(
             *connection.state.lock().unwrap(),
-            GrpcConnectionState::Initialized
+            CommandInterfaceState::Initialized
         );
     }
 
     #[tokio::test]
-    async fn utest_grpc_connection_disconnect_without_connect_fails() {
-        let (mut connection, _response_receiver) = generate_test_grpc_connection();
+    async fn utest_command_interface_disconnect_without_connect_fails() {
+        let (mut connection, _response_receiver) = generate_test_command_interface_connection();
         let result = connection.disconnect();
         assert!(result.is_err());
         assert!(matches!(result, Err(AnkaiosError::ConnectionError(_))));
     }
 
     #[tokio::test]
-    async fn utest_grpc_connection_write_request_fails_when_not_connected() {
-        let (mut connection, _response_receiver) = generate_test_grpc_connection();
+    async fn utest_command_interface_write_request_fails_when_not_connected() {
+        let (mut connection, _response_receiver) = generate_test_command_interface_connection();
         let result = connection
             .write_request(crate::ankaios_api::ank_base::Request::default())
             .await;
@@ -671,11 +671,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn utest_grpc_connection_write_request_succeeds_when_connected() {
-        let (mut connection, _response_receiver) = generate_test_grpc_connection();
+    async fn utest_command_interface_write_request_succeeds_when_connected() {
+        let (mut connection, _response_receiver) = generate_test_command_interface_connection();
         let (grpc_tx, mut grpc_rx) = mpsc::channel::<ToServer>(CHANNEL_SIZE);
         *connection.writer_ch_sender.lock().unwrap() = Some(grpc_tx);
-        *connection.state.lock().unwrap() = GrpcConnectionState::Connected;
+        *connection.state.lock().unwrap() = CommandInterfaceState::Connected;
 
         let request = generate_test_request().to_proto();
         let result = connection.write_request(request.clone()).await;
@@ -688,8 +688,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn utest_grpc_connection_log_campaign() {
-        let (mut connection, _response_receiver) = generate_test_grpc_connection();
+    async fn utest_command_interface_log_campaign() {
+        let (mut connection, _response_receiver) = generate_test_command_interface_connection();
         let (logs_sender, _logs_receiver) = mpsc::channel(CHANNEL_SIZE);
 
         connection.add_log_campaign(REQUEST_ID.to_owned(), logs_sender);
@@ -714,8 +714,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn utest_grpc_connection_events_campaign() {
-        let (mut connection, _response_receiver) = generate_test_grpc_connection();
+    async fn utest_command_interface_events_campaign() {
+        let (mut connection, _response_receiver) = generate_test_command_interface_connection();
         let (events_sender, _events_receiver) = mpsc::channel(CHANNEL_SIZE);
 
         connection.add_events_campaign(REQUEST_ID.to_owned(), events_sender);
@@ -740,13 +740,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn utest_grpc_handle_decoded_response_forwards_generic_response() {
-        let (connection, mut response_receiver) = generate_test_grpc_connection();
+    async fn utest_command_interface_handle_decoded_response_forwards_generic_response() {
+        let (connection, mut response_receiver) = generate_test_command_interface_connection();
         let mut log_senders_map = connection.log_senders_map.clone();
         let mut events_senders_map = connection.events_senders_map.clone();
         let ank_base_response = generate_test_ank_base_update_state_success(REQUEST_ID.to_owned());
 
-        GrpcConnection::handle_decoded_response(
+        CommandInterfaceConnection::handle_decoded_response(
             FromServer {
                 from_server_enum: Some(FromServerEnum::Response(ank_base_response)),
             },
@@ -764,8 +764,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn utest_grpc_handle_decoded_response_forwards_log_entries() {
-        let (connection, _response_receiver) = generate_test_grpc_connection();
+    async fn utest_command_interface_handle_decoded_response_forwards_log_entries() {
+        let (connection, _response_receiver) = generate_test_command_interface_connection();
         let mut log_senders_map = connection.log_senders_map.clone();
         let mut events_senders_map = connection.events_senders_map.clone();
         let (logs_sender, mut logs_receiver) = mpsc::channel::<LogResponse>(CHANNEL_SIZE);
@@ -778,7 +778,7 @@ mod tests {
             )),
         };
 
-        GrpcConnection::handle_decoded_response(
+        CommandInterfaceConnection::handle_decoded_response(
             FromServer {
                 from_server_enum: Some(FromServerEnum::Response(ank_base_response)),
             },
@@ -795,8 +795,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn utest_grpc_handle_decoded_response_forwards_logs_stop_response() {
-        let (connection, _response_receiver) = generate_test_grpc_connection();
+    async fn utest_command_interface_handle_decoded_response_forwards_logs_stop_response() {
+        let (connection, _response_receiver) = generate_test_command_interface_connection();
         let mut log_senders_map = connection.log_senders_map.clone();
         let mut events_senders_map = connection.events_senders_map.clone();
         let (logs_sender, mut logs_receiver) = mpsc::channel::<LogResponse>(CHANNEL_SIZE);
@@ -815,7 +815,7 @@ mod tests {
             )),
         };
 
-        GrpcConnection::handle_decoded_response(
+        CommandInterfaceConnection::handle_decoded_response(
             FromServer {
                 from_server_enum: Some(FromServerEnum::Response(ank_base_response)),
             },
@@ -832,8 +832,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn utest_grpc_handle_decoded_response_forwards_event_response() {
-        let (connection, _response_receiver) = generate_test_grpc_connection();
+    async fn utest_command_interface_handle_decoded_response_forwards_event_response() {
+        let (connection, _response_receiver) = generate_test_command_interface_connection();
         let mut log_senders_map = connection.log_senders_map.clone();
         let mut events_senders_map = connection.events_senders_map.clone();
         let (events_sender, mut events_receiver) = mpsc::channel::<EventEntry>(CHANNEL_SIZE);
@@ -853,7 +853,7 @@ mod tests {
             ))),
         };
 
-        GrpcConnection::handle_decoded_response(
+        CommandInterfaceConnection::handle_decoded_response(
             FromServer {
                 from_server_enum: Some(FromServerEnum::Response(ank_base_response)),
             },
@@ -874,8 +874,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn utest_grpc_handle_decoded_response_ignores_non_response_messages() {
-        let (connection, mut response_receiver) = generate_test_grpc_connection();
+    async fn utest_command_interface_handle_decoded_response_ignores_non_response_messages() {
+        let (connection, mut response_receiver) = generate_test_command_interface_connection();
         let mut log_senders_map = connection.log_senders_map.clone();
         let mut events_senders_map = connection.events_senders_map.clone();
 
@@ -889,7 +889,7 @@ mod tests {
             ),
             FromServerEnum::UpdateWorkload(crate::ankaios_api::grpc_api::UpdateWorkload::default()),
         ] {
-            GrpcConnection::handle_decoded_response(
+            CommandInterfaceConnection::handle_decoded_response(
                 FromServer {
                     from_server_enum: Some(from_server_enum),
                 },
@@ -899,7 +899,7 @@ mod tests {
             )
             .await;
         }
-        GrpcConnection::handle_decoded_response(
+        CommandInterfaceConnection::handle_decoded_response(
             FromServer {
                 from_server_enum: None,
             },
@@ -915,7 +915,7 @@ mod tests {
     #[tokio::test]
     async fn utest_run_reader_loop_reconnects_after_stream_drop() {
         let (response_sender, mut response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
-        let state = Arc::new(Mutex::new(GrpcConnectionState::Connected));
+        let state = Arc::new(Mutex::new(CommandInterfaceState::Connected));
         let writer_ch_sender = Arc::new(Mutex::new(None));
 
         let mut mock_transport = MockReaderTransport::new();
@@ -967,15 +967,18 @@ mod tests {
         // reconnect and (harmlessly) panic on the unmocked call after that.
         sleep(Duration::from_secs(2)).await;
 
-        assert_eq!(*state.lock().unwrap(), GrpcConnectionState::Connected);
+        assert_eq!(*state.lock().unwrap(), CommandInterfaceState::Connected);
         assert!(writer_ch_sender.lock().unwrap().is_some());
-        assert!(task.is_finished(), "task should have ended (panicked on the unmocked call)");
+        assert!(
+            task.is_finished(),
+            "task should have ended (panicked on the unmocked call)"
+        );
     }
 
     #[tokio::test]
     async fn utest_run_reader_loop_stops_reconnecting_once_terminated() {
         let (response_sender, _response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
-        let state = Arc::new(Mutex::new(GrpcConnectionState::Connected));
+        let state = Arc::new(Mutex::new(CommandInterfaceState::Connected));
         let writer_ch_sender = Arc::new(Mutex::new(None));
 
         let mut mock_transport = MockReaderTransport::new();
@@ -984,7 +987,7 @@ mod tests {
         // attempt_connect() must never be called once disconnect() has set Terminated.
         mock_transport.expect_attempt_connect().times(0);
 
-        *state.lock().unwrap() = GrpcConnectionState::Terminated;
+        *state.lock().unwrap() = CommandInterfaceState::Terminated;
 
         let task = tokio::spawn(run_reader_loop(
             mock_transport,

--- a/src/components/connection/control_interface.rs
+++ b/src/components/connection/control_interface.rs
@@ -32,7 +32,6 @@ use tokio::{
     time::{Duration, sleep, timeout as tokio_timeout},
 };
 
-use async_trait::async_trait;
 use crate::components::connection::{ANKAIOS_VERSION, Connection, SynchronizedSenderMap};
 use crate::components::event_types::EventEntry;
 use crate::components::log_types::LogResponse;
@@ -40,6 +39,7 @@ use crate::components::response::{Response, ResponseType};
 use crate::{AnkaiosError, ankaios_api};
 use ankaios_api::ank_base::Request as AnkaiosRequest;
 use ankaios_api::control_api::{FromAnkaios, Hello, ToAnkaios, to_ankaios::ToAnkaiosEnum};
+use async_trait::async_trait;
 
 /// Base path for the control interface FIFO pipes.
 const ANKAIOS_CONTROL_INTERFACE_BASE_PATH: &str = "/run/ankaios/control_interface";
@@ -524,11 +524,7 @@ impl Connection for ControlInterface {
         }
     }
 
-    fn add_events_campaign(
-        &mut self,
-        request_id: String,
-        events_sender: mpsc::Sender<EventEntry>,
-    ) {
+    fn add_events_campaign(&mut self, request_id: String, events_sender: mpsc::Sender<EventEntry>) {
         log::trace!("Add event campaign with request id: '{request_id}'");
 
         self.events_senders_map.insert(request_id, events_sender);
@@ -570,7 +566,9 @@ mod tests {
         ANKAIOS_INPUT_FIFO_PATH, ANKAIOS_OUTPUT_FIFO_PATH, ANKAIOS_VERSION, ControlInterface,
         ControlInterfaceState, read_protobuf_data,
     };
-    use crate::components::connection::{Connection, forward_log_entries, forward_logs_stop_response};
+    use crate::components::connection::{
+        Connection, forward_log_entries, forward_logs_stop_response,
+    };
     use crate::{
         AnkaiosError, EventEntry, LogResponse,
         ankaios::CHANNEL_SIZE,

--- a/src/components/connection/control_interface.rs
+++ b/src/components/connection/control_interface.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! This module contains the [`ControlInterface`] struct and the [`ControlInterfaceState`] enum,
-//! implementing the [`Connection`] trait over the
+//! This module contains the [`ControlInterfaceConnection`] struct and the
+//! [`ControlInterfaceState`] enum, implementing the [`Connection`] trait over the
 //! [Ankaios](https://eclipse-ankaios.github.io/ankaios) control interface (named pipes), used to
 //! connect to Ankaios from inside a workload.
 
@@ -50,19 +50,19 @@ const ANKAIOS_OUTPUT_FIFO_PATH: &str = "output";
 /// Maximum size of a varint in bytes.
 const MAX_VARINT_SIZE: usize = 19;
 
-/// Enum representing the state of the control interface.
+/// Enum representing the state of the control interface connection.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum ControlInterfaceState {
-    /// The control interface was initialized.
+    /// The connection to the control interface was initialized.
     Initialized = 1,
-    /// The control interface is established.
+    /// The connection to the control interface is established.
     Connected = 2,
-    /// The control interface is terminated.
+    /// The connection to the control interface is terminated.
     Terminated = 3,
     /// The agent is disconnected.
     AgentDisconnected = 4,
-    /// The connection is closed. This state is unrecoverable.
+    /// The connection to the control interface is closed. This state is unrecoverable.
     ConnectionClosed = 5,
 }
 
@@ -71,7 +71,7 @@ pub enum ControlInterfaceState {
 ///
 /// It uses two [tokio] tasks, one for reading from the input FIFO and one for
 /// writing to the output FIFO.
-pub struct ControlInterface {
+pub struct ControlInterfaceConnection {
     /// Path to the FIFO pipes directory.
     pub(crate) path: String,
     /// Output file for writing to the control interface.
@@ -135,8 +135,8 @@ async fn read_protobuf_data(file: &mut BufReader<pipe::Receiver>) -> Result<Vec<
     Ok(buf)
 }
 
-impl ControlInterface {
-    /// Creates a new instance of the control interface.
+impl ControlInterfaceConnection {
+    /// Creates a new instance of the control interface connection.
     ///
     /// ## Arguments
     ///
@@ -144,7 +144,7 @@ impl ControlInterface {
     ///
     /// ## Returns
     ///
-    /// A new [`ControlInterface`] instance.
+    /// A new [`ControlInterfaceConnection`] instance.
     pub fn new(response_sender: mpsc::Sender<Response>) -> Self {
         Self {
             path: ANKAIOS_CONTROL_INTERFACE_BASE_PATH.to_owned(),
@@ -159,8 +159,8 @@ impl ControlInterface {
         }
     }
 
-    /// Changes the state of the control interface.
-    /// This method should be used for all state changes inside the control interface.
+    /// Changes the state of the control interface connection.
+    /// This method should be used for all state changes inside the connection.
     ///
     /// ## Arguments
     ///
@@ -177,7 +177,7 @@ impl ControlInterface {
         log::info!("State changed: {new_state:?}");
     }
 
-    /// Prepares the writer thread for the control interface.
+    /// Prepares the writer thread for the control interface connection.
     /// It uses a [tokio] task that waits for messages and sends them to the output FIFO.
     fn prepare_writer(&mut self) {
         let (writer_ch_sender, mut writer_ch_receiver) = mpsc::channel::<ToAnkaios>(5);
@@ -209,14 +209,14 @@ impl ControlInterface {
                         if *state_clone.lock().unwrap_or_else(|_| unreachable!())
                             == ControlInterfaceState::Connected
                         {
-                            ControlInterface::change_state(
+                            ControlInterfaceConnection::change_state(
                                 &state_clone,
                                 ControlInterfaceState::AgentDisconnected,
                             );
                         }
                         log::warn!("Waiting for the agent..");
                         sleep(Duration::from_secs(AGENT_RECONNECT_INTERVAL)).await;
-                        ControlInterface::send_initial_hello(&writer_ch_sender).await;
+                        ControlInterfaceConnection::send_initial_hello(&writer_ch_sender).await;
                     } else {
                         log::error!("Error while flushing to output fifo: '{err}'");
                         // let _ = self.disconnect();
@@ -224,7 +224,7 @@ impl ControlInterface {
                 } else if *state_clone.lock().unwrap_or_else(|_| unreachable!())
                     == ControlInterfaceState::AgentDisconnected
                 {
-                    ControlInterface::change_state(
+                    ControlInterfaceConnection::change_state(
                         &state_clone,
                         ControlInterfaceState::Initialized,
                     );
@@ -234,7 +234,7 @@ impl ControlInterface {
         }));
     }
 
-    /// Prepares the reader thread for the control interface.
+    /// Prepares the reader thread for the control interface connection.
     /// It uses a [tokio] task that reads continuously from the FIFO input pipe.
     fn read_from_control_interface(&mut self) {
         #[cfg(not(test))]
@@ -354,7 +354,10 @@ impl ControlInterface {
             ControlInterfaceState::Initialized => {
                 if received_response.content == ResponseType::ControlInterfaceAccepted {
                     log::debug!("Received control interface accepted response.");
-                    ControlInterface::change_state(state, ControlInterfaceState::Connected);
+                    ControlInterfaceConnection::change_state(
+                        state,
+                        ControlInterfaceState::Connected,
+                    );
                 }
             }
             ControlInterfaceState::Connected => match received_response.content {
@@ -420,7 +423,7 @@ impl ControlInterface {
 }
 
 #[async_trait]
-impl Connection for ControlInterface {
+impl Connection for ControlInterfaceConnection {
     async fn connect(&mut self, timeout: Duration) -> Result<(), AnkaiosError> {
         if matches!(
             *self.state.lock().unwrap_or_else(|_| unreachable!()),
@@ -443,8 +446,8 @@ impl Connection for ControlInterface {
 
         self.prepare_writer();
         self.read_from_control_interface();
-        ControlInterface::change_state(&self.state, ControlInterfaceState::Initialized);
-        ControlInterface::send_initial_hello(
+        ControlInterfaceConnection::change_state(&self.state, ControlInterfaceState::Initialized);
+        ControlInterfaceConnection::send_initial_hello(
             self.writer_ch_sender
                 .as_ref()
                 .unwrap_or_else(|| unreachable!()),
@@ -563,8 +566,8 @@ mod tests {
     };
 
     use super::{
-        ANKAIOS_INPUT_FIFO_PATH, ANKAIOS_OUTPUT_FIFO_PATH, ANKAIOS_VERSION, ControlInterface,
-        ControlInterfaceState, read_protobuf_data,
+        ANKAIOS_INPUT_FIFO_PATH, ANKAIOS_OUTPUT_FIFO_PATH, ANKAIOS_VERSION,
+        ControlInterfaceConnection, ControlInterfaceState, read_protobuf_data,
     };
     use crate::components::connection::{
         Connection, forward_log_entries, forward_logs_stop_response,
@@ -590,7 +593,7 @@ mod tests {
     const CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
 
     /// Helper function for getting the state of the control interface.
-    fn get_state(ci: &ControlInterface) -> ControlInterfaceState {
+    fn get_state(ci: &ControlInterfaceConnection) -> ControlInterfaceState {
         let state = ci.state.lock().unwrap();
         *state
     }
@@ -651,7 +654,7 @@ mod tests {
         let fifo_output = tmpdir.path().join(ANKAIOS_OUTPUT_FIFO_PATH);
 
         // Create control interface
-        let mut ci = ControlInterface::new(response_sender);
+        let mut ci = ControlInterfaceConnection::new(response_sender);
         tmpdir.path().to_str().unwrap().clone_into(&mut ci.path);
         assert_eq!(get_state(&ci), ControlInterfaceState::Terminated);
 
@@ -729,7 +732,7 @@ mod tests {
         let fifo_output = tmpdir.path().join(ANKAIOS_OUTPUT_FIFO_PATH);
 
         // Create control interface
-        let mut ci = ControlInterface::new(response_sender);
+        let mut ci = ControlInterfaceConnection::new(response_sender);
         tmpdir.path().to_str().unwrap().clone_into(&mut ci.path);
         assert_eq!(get_state(&ci), ControlInterfaceState::Terminated);
 
@@ -770,7 +773,7 @@ mod tests {
         );
 
         // Create control interface
-        let mut ci = ControlInterface::new(response_sender);
+        let mut ci = ControlInterfaceConnection::new(response_sender);
         tmpdir.path().to_str().unwrap().clone_into(&mut ci.path);
         assert_eq!(get_state(&ci), ControlInterfaceState::Terminated);
 
@@ -892,7 +895,7 @@ mod tests {
         });
 
         // Create control interface
-        let mut ci = ControlInterface::new(response_sender);
+        let mut ci = ControlInterfaceConnection::new(response_sender);
         tmpdir.path().to_str().unwrap().clone_into(&mut ci.path);
         assert_eq!(get_state(&ci), ControlInterfaceState::Terminated);
         sleep(Duration::from_millis(10)).await;
@@ -980,7 +983,7 @@ mod tests {
         let (response_sender, mut response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
 
         // Create control interface
-        let mut ci = ControlInterface::new(response_sender);
+        let mut ci = ControlInterfaceConnection::new(response_sender);
         let state = Arc::clone(&ci.state);
 
         // Create responses to test the method
@@ -990,7 +993,7 @@ mod tests {
 
         // Test invalid state
         *state.lock().unwrap() = ControlInterfaceState::Terminated;
-        ControlInterface::handle_decoded_response(
+        ControlInterfaceConnection::handle_decoded_response(
             &state,
             update_state_response.clone(),
             &ci.response_sender,
@@ -1002,7 +1005,7 @@ mod tests {
 
         // Test initialized state - received control interface accepted response
         *state.lock().unwrap() = ControlInterfaceState::Initialized;
-        ControlInterface::handle_decoded_response(
+        ControlInterfaceConnection::handle_decoded_response(
             &state,
             ci_accepted_response.clone(),
             &ci.response_sender,
@@ -1013,7 +1016,7 @@ mod tests {
         assert!(matches!(get_state(&ci), ControlInterfaceState::Connected));
 
         // Test connected state - received unexpected control interface accepted response
-        ControlInterface::handle_decoded_response(
+        ControlInterfaceConnection::handle_decoded_response(
             &state,
             ci_accepted_response,
             &ci.response_sender,
@@ -1024,7 +1027,7 @@ mod tests {
 
         // Test connected state - received valid response
         response_receiver.try_recv().unwrap_err(); // No response should be sent
-        ControlInterface::handle_decoded_response(
+        ControlInterfaceConnection::handle_decoded_response(
             &state,
             update_state_response,
             &ci.response_sender,
@@ -1052,7 +1055,7 @@ mod tests {
         mkfifo(&fifo_output, Mode::S_IRWXU).unwrap();
 
         // Create control interface
-        let mut ci = ControlInterface::new(response_sender);
+        let mut ci = ControlInterfaceConnection::new(response_sender);
         tmpdir.path().to_str().unwrap().clone_into(&mut ci.path);
         let (logs_sender, mut logs_receiver) = mpsc::channel::<LogResponse>(CHANNEL_SIZE);
         ci.log_senders_map
@@ -1112,7 +1115,7 @@ mod tests {
         let (response_sender, mut response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
 
         // Create control interface
-        let mut ci = ControlInterface::new(response_sender);
+        let mut ci = ControlInterfaceConnection::new(response_sender);
 
         let (logs_sender, mut logs_receiver) = mpsc::channel::<LogResponse>(CHANNEL_SIZE);
         ci.log_senders_map
@@ -1151,7 +1154,7 @@ mod tests {
         let (response_sender, _response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
 
         // Create control interface
-        let mut ci = ControlInterface::new(response_sender);
+        let mut ci = ControlInterfaceConnection::new(response_sender);
         let state = ci.state;
         *state.lock().unwrap() = ControlInterfaceState::Connected;
 
@@ -1174,7 +1177,7 @@ mod tests {
         let response =
             generate_test_logs_stop_response(REQUEST_ID_1.to_owned(), instance_name_1.clone());
 
-        ControlInterface::handle_decoded_response(
+        ControlInterfaceConnection::handle_decoded_response(
             &state,
             response,
             &ci.response_sender,
@@ -1194,7 +1197,7 @@ mod tests {
         let response =
             generate_test_logs_stop_response(REQUEST_ID_1.to_owned(), instance_name_2.clone());
 
-        ControlInterface::handle_decoded_response(
+        ControlInterfaceConnection::handle_decoded_response(
             &state,
             response,
             &ci.response_sender,
@@ -1220,7 +1223,7 @@ mod tests {
         let (response_sender, mut response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
 
         // Create control interface
-        let mut ci = ControlInterface::new(response_sender);
+        let mut ci = ControlInterfaceConnection::new(response_sender);
 
         let (logs_sender, mut logs_receiver) = mpsc::channel::<LogResponse>(CHANNEL_SIZE);
         ci.log_senders_map
@@ -1268,7 +1271,7 @@ mod tests {
         let (response_sender, _response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
 
         // Create control interface
-        let mut ci = ControlInterface::new(response_sender);
+        let mut ci = ControlInterfaceConnection::new(response_sender);
         let state = ci.state;
         *state.lock().unwrap() = ControlInterfaceState::Connected;
 
@@ -1280,7 +1283,7 @@ mod tests {
         let event_entry_response = generate_test_response_event_entry(REQUEST_ID_1.to_owned());
 
         // Handle event entry response
-        ControlInterface::handle_decoded_response(
+        ControlInterfaceConnection::handle_decoded_response(
             &state,
             event_entry_response,
             &ci.response_sender,
@@ -1317,7 +1320,7 @@ mod tests {
         let event_entry_response = generate_test_response_event_entry(REQUEST_ID_2.to_owned());
 
         // Handle event entry response
-        ControlInterface::handle_decoded_response(
+        ControlInterfaceConnection::handle_decoded_response(
             &state,
             event_entry_response,
             &ci.response_sender,
@@ -1333,7 +1336,7 @@ mod tests {
     #[tokio::test]
     async fn utest_control_interface_add_log_campaign() {
         let (response_sender, _) = mpsc::channel::<Response>(CHANNEL_SIZE);
-        let mut ci = ControlInterface::new(response_sender);
+        let mut ci = ControlInterfaceConnection::new(response_sender);
 
         let (logs_sender_1, _) = mpsc::channel::<LogResponse>(CHANNEL_SIZE);
         ci.add_log_campaign(REQUEST_ID_1.to_owned(), logs_sender_1);
@@ -1357,7 +1360,7 @@ mod tests {
     #[tokio::test]
     async fn utest_control_interface_remove_log_campaign() {
         let (response_sender, _) = mpsc::channel::<Response>(CHANNEL_SIZE);
-        let mut ci = ControlInterface::new(response_sender);
+        let mut ci = ControlInterfaceConnection::new(response_sender);
 
         let (logs_sender_1, _) = mpsc::channel::<LogResponse>(CHANNEL_SIZE);
         ci.log_senders_map
@@ -1396,7 +1399,7 @@ mod tests {
     #[tokio::test]
     async fn utest_control_interface_add_events_campaign() {
         let (response_sender, _) = mpsc::channel::<Response>(CHANNEL_SIZE);
-        let mut ci = ControlInterface::new(response_sender);
+        let mut ci = ControlInterfaceConnection::new(response_sender);
 
         let (events_sender_1, _) = mpsc::channel::<EventEntry>(CHANNEL_SIZE);
         ci.add_events_campaign(REQUEST_ID_1.to_owned(), events_sender_1);
@@ -1420,7 +1423,7 @@ mod tests {
     #[tokio::test]
     async fn utest_control_interface_remove_events_campaign() {
         let (response_sender, _) = mpsc::channel::<Response>(CHANNEL_SIZE);
-        let mut ci = ControlInterface::new(response_sender);
+        let mut ci = ControlInterfaceConnection::new(response_sender);
 
         let (events_sender_1, _) = mpsc::channel::<EventEntry>(CHANNEL_SIZE);
         ci.events_senders_map

--- a/src/components/connection/control_interface.rs
+++ b/src/components/connection/control_interface.rs
@@ -12,11 +12,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! This module contains the [`ControlInterface`] struct and the [`ControlInterfaceState`] enum.
+//! This module contains the [`ControlInterface`] struct and the [`ControlInterfaceState`] enum,
+//! implementing the [`Connection`] trait over the
+//! [Ankaios](https://eclipse-ankaios.github.io/ankaios) control interface (named pipes), used to
+//! connect to Ankaios from inside a workload.
 
 use prost::{Message, encoding::decode_varint};
 use std::{
-    collections::HashMap,
     fs::metadata,
     path::Path,
     sync::{Arc, Mutex},
@@ -30,16 +32,14 @@ use tokio::{
     time::{Duration, sleep, timeout as tokio_timeout},
 };
 
+use async_trait::async_trait;
+use crate::components::connection::{ANKAIOS_VERSION, Connection, SynchronizedSenderMap};
 use crate::components::event_types::EventEntry;
-use crate::components::log_types::{LogEntry, LogResponse};
-use crate::components::request::Request;
+use crate::components::log_types::LogResponse;
 use crate::components::response::{Response, ResponseType};
-use crate::components::workload_state_mod::WorkloadInstanceName;
 use crate::{AnkaiosError, ankaios_api};
+use ankaios_api::ank_base::Request as AnkaiosRequest;
 use ankaios_api::control_api::{FromAnkaios, Hello, ToAnkaios, to_ankaios::ToAnkaiosEnum};
-
-#[cfg(test)]
-use mockall::automock;
 
 /// Base path for the control interface FIFO pipes.
 const ANKAIOS_CONTROL_INTERFACE_BASE_PATH: &str = "/run/ankaios/control_interface";
@@ -47,9 +47,6 @@ const ANKAIOS_CONTROL_INTERFACE_BASE_PATH: &str = "/run/ankaios/control_interfac
 const ANKAIOS_INPUT_FIFO_PATH: &str = "input";
 /// Output fifo path from the base path
 const ANKAIOS_OUTPUT_FIFO_PATH: &str = "output";
-/// Version of [Ankaios](https://eclipse-ankaios.github.io/ankaios) that is compatible
-/// with the [`ControlInterface`] implementation.
-const ANKAIOS_VERSION: &str = "1.0.0";
 /// Maximum size of a varint in bytes.
 const MAX_VARINT_SIZE: usize = 19;
 
@@ -67,70 +64,6 @@ pub enum ControlInterfaceState {
     AgentDisconnected = 4,
     /// The connection is closed. This state is unrecoverable.
     ConnectionClosed = 5,
-}
-
-#[doc(hidden)]
-#[derive(Debug, Clone)]
-struct SynchronizedSenderMap<T> {
-    /// A map of request IDs to their corresponding senders.
-    senders_map: Arc<Mutex<HashMap<String, mpsc::Sender<T>>>>,
-}
-
-impl<T> SynchronizedSenderMap<T> {
-    /// Inserts a new sender for a request ID part of a started campaign.
-    ///
-    /// ## Arguments
-    ///
-    /// * `request_id` - A [String] representing the request ID;
-    /// * `sender` - A [`mpsc::Sender<T>`] to forward campaign messages.
-    ///
-    fn insert(&mut self, request_id: String, sender: mpsc::Sender<T>) {
-        self.senders_map
-            .lock()
-            .unwrap_or_else(|_| unreachable!())
-            .insert(request_id, sender);
-    }
-
-    /// Removes a sender by its request ID.
-    ///
-    /// ## Arguments
-    ///
-    /// * `request_id` - A [String] representing the request ID.
-    ///
-    /// ## Returns
-    ///
-    /// An [`Option<mpsc::Sender<T>>`] if the request ID was found and removed, otherwise `None`.
-    fn remove(&mut self, request_id: &str) -> Option<mpsc::Sender<T>> {
-        self.senders_map
-            .lock()
-            .unwrap_or_else(|_| unreachable!())
-            .remove(request_id)
-    }
-
-    /// Gets a cloned sender by its request ID.
-    ///
-    /// ## Arguments
-    ///
-    /// * `request_id` - A [String] representing the request ID.
-    ///
-    /// ## Returns
-    ///
-    /// An [`Option<mpsc::Sender<T>>`] if the request ID was found, otherwise `None`.
-    fn get_cloned(&self, request_id: &str) -> Option<mpsc::Sender<T>> {
-        self.senders_map
-            .lock()
-            .unwrap_or_else(|_| unreachable!())
-            .get(request_id)
-            .cloned()
-    }
-}
-
-impl<T> Default for SynchronizedSenderMap<T> {
-    fn default() -> Self {
-        SynchronizedSenderMap {
-            senders_map: Arc::new(Mutex::new(HashMap::new())),
-        }
-    }
 }
 
 /// This struct handles the interaction with the control interface.
@@ -202,7 +135,6 @@ async fn read_protobuf_data(file: &mut BufReader<pipe::Receiver>) -> Result<Vec<
     Ok(buf)
 }
 
-#[cfg_attr(test, automock)]
 impl ControlInterface {
     /// Creates a new instance of the control interface.
     ///
@@ -225,88 +157,6 @@ impl ControlInterface {
             log_senders_map: SynchronizedSenderMap::default(),
             events_senders_map: SynchronizedSenderMap::default(),
         }
-    }
-
-    /// Connects to the control interface.
-    ///
-    /// ## Returns
-    ///
-    /// An [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if the connection fails.
-    pub async fn connect(&mut self, timeout: Duration) -> Result<(), AnkaiosError> {
-        if matches!(
-            *self.state.lock().unwrap_or_else(|_| unreachable!()),
-            ControlInterfaceState::Initialized | ControlInterfaceState::Connected
-        ) {
-            return Err(AnkaiosError::ControlInterfaceError(
-                "Already connected.".to_owned(),
-            ));
-        }
-        if metadata(&(self.path.clone() + "/" + ANKAIOS_INPUT_FIFO_PATH)).is_err() {
-            return Err(AnkaiosError::ControlInterfaceError(
-                "Control interface input fifo does not exist.".to_owned(),
-            ));
-        }
-        if metadata(&(self.path.clone() + "/" + ANKAIOS_OUTPUT_FIFO_PATH)).is_err() {
-            return Err(AnkaiosError::ControlInterfaceError(
-                "Control interface output fifo does not exist.".to_owned(),
-            ));
-        }
-
-        self.prepare_writer();
-        self.read_from_control_interface();
-        ControlInterface::change_state(&self.state, ControlInterfaceState::Initialized);
-        ControlInterface::send_initial_hello(
-            self.writer_ch_sender
-                .as_ref()
-                .unwrap_or_else(|| unreachable!()),
-        )
-        .await;
-
-        // Wait for the connection to be established
-        let state_clone = Arc::<Mutex<ControlInterfaceState>>::clone(&self.state);
-        if (tokio_timeout(timeout, async {
-            while *state_clone.lock().unwrap_or_else(|_| unreachable!())
-                != ControlInterfaceState::Connected
-            {
-                sleep(Duration::from_millis(100)).await;
-            }
-        })
-        .await)
-            .is_err()
-        {
-            log::error!("Connection to the control interface timed out.");
-            return Err(AnkaiosError::ControlInterfaceError(
-                "Connection to the control interface timed out.".to_owned(),
-            ));
-        }
-
-        log::trace!("Connected to the control interface.");
-        Ok(())
-    }
-
-    /// Disconnects from the control interface.
-    ///
-    /// ## Returns
-    ///
-    /// An [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if the disconnection fails.
-    pub fn disconnect(&mut self) -> Result<(), AnkaiosError> {
-        if !matches!(
-            *self.state.lock().unwrap_or_else(|_| unreachable!()),
-            ControlInterfaceState::Initialized | ControlInterfaceState::Connected
-        ) {
-            return Err(AnkaiosError::ControlInterfaceError(
-                "Already disconnected.".to_owned(),
-            ));
-        }
-        if let Some(handler) = self.read_thread_handler.take() {
-            handler.abort();
-        }
-        self.state
-            .lock()
-            .unwrap_or_else(|_| unreachable!())
-            .clone_from(&ControlInterfaceState::Terminated);
-        self.output_file = None;
-        Ok(())
     }
 
     /// Changes the state of the control interface.
@@ -341,7 +191,7 @@ impl ControlInterface {
             let sender = pipe::OpenOptions::new()
                 .open_sender(output_path)
                 .map_err(|_| {
-                    AnkaiosError::ControlInterfaceError("Could not open output fifo.".to_owned())
+                    AnkaiosError::ConnectionError("Could not open output fifo.".to_owned())
                 })?;
             let mut output_file = BufWriter::new(sender);
 
@@ -407,7 +257,7 @@ impl ControlInterface {
             let receiver = pipe::OpenOptions::new()
                 .open_receiver(input_path)
                 .map_err(|_| {
-                    AnkaiosError::ControlInterfaceError("Could not open input fifo.".to_owned())
+                    AnkaiosError::ConnectionError("Could not open input fifo.".to_owned())
                 })?;
             let mut input_file = BufReader::new(receiver);
 
@@ -509,11 +359,11 @@ impl ControlInterface {
             }
             ControlInterfaceState::Connected => match received_response.content {
                 ResponseType::LogEntriesResponse(log_entries) => {
-                    Self::forward_log_entries(received_response.id, log_entries, logs_sender_map)
+                    super::forward_log_entries(received_response.id, log_entries, logs_sender_map)
                         .await;
                 }
                 ResponseType::LogsStopResponse(instance_name) => {
-                    Self::forward_logs_stop_response(
+                    super::forward_logs_stop_response(
                         received_response.id,
                         instance_name,
                         logs_sender_map,
@@ -521,7 +371,7 @@ impl ControlInterface {
                     .await;
                 }
                 ResponseType::EventResponse(event_entry) => {
-                    Self::forward_event_response(
+                    super::forward_event_response(
                         received_response.id,
                         event_entry,
                         event_sender_map,
@@ -548,188 +398,6 @@ impl ControlInterface {
         }
     }
 
-    /// Writes a request to the control interface.
-    ///
-    /// ## Arguments
-    ///
-    /// * `request` - A [`Request`] object to be sent.
-    ///
-    /// ## Returns
-    ///
-    /// An [`AnkaiosError`]::[`ControlInterfaceError`](AnkaiosError::ControlInterfaceError) if not connected.
-    pub async fn write_request<T: Request + 'static>(
-        &mut self,
-        request: T,
-    ) -> Result<(), AnkaiosError> {
-        if *self.state.lock().unwrap_or_else(|_| unreachable!()) != ControlInterfaceState::Connected
-        {
-            log::error!("Could not write to pipe, not connected.");
-            return Err(AnkaiosError::ControlInterfaceError(
-                "Could not write to pipe, not connected.".to_owned(),
-            ));
-        }
-        let message = ToAnkaios {
-            to_ankaios_enum: Some(ToAnkaiosEnum::Request(request.to_proto())),
-        };
-        if let Some(sender) = self.writer_ch_sender.as_ref() {
-            sender.send(message).await.unwrap_or_else(|err| {
-                log::error!("Error while sending request: '{err}'");
-            });
-        }
-        Ok(())
-    }
-
-    #[doc(hidden)]
-    /// Adds a log campaign to the control interface.
-    ///
-    /// ## Arguments
-    ///
-    /// * `request_id` - A [String] representing the request ID of the initial logs request of the log campaign;
-    /// * `logs_sender` - A [`mpsc::Sender<LogResponse>`] to forward log responses for the log campaign.
-    ///
-    pub fn add_log_campaign(&mut self, request_id: String, logs_sender: mpsc::Sender<LogResponse>) {
-        log::trace!("Add log campaign with request id: '{request_id}'");
-
-        self.log_senders_map.insert(request_id, logs_sender);
-    }
-
-    #[doc(hidden)]
-    /// Removes a log campaign from the control interface.
-    ///
-    /// ## Arguments
-    ///
-    /// * `request_id` - A [&str] representing the request ID of the initial logs request of the log campaign;
-    ///
-    pub fn remove_log_campaign(&mut self, request_id: &str) {
-        if self.log_senders_map.remove(request_id).is_some() {
-            log::trace!("Removed log campaign with request id: '{request_id}'");
-        }
-    }
-
-    #[doc(hidden)]
-    /// Adds an events campaign to the control interface.
-    ///
-    /// ## Arguments
-    ///
-    /// * `request_id` - A [String] representing the request ID of the initial events campaign;
-    /// * `events_sender` - A [`mpsc::Sender<EventEntry>`] to forward events for the campaign.
-    ///
-    pub fn add_events_campaign(
-        &mut self,
-        request_id: String,
-        events_sender: mpsc::Sender<EventEntry>,
-    ) {
-        log::trace!("Add event campaign with request id: '{request_id}'");
-
-        self.events_senders_map.insert(request_id, events_sender);
-    }
-
-    #[doc(hidden)]
-    /// Removes an events campaign from the control interface.
-    ///
-    /// ## Arguments
-    ///
-    /// * `request_id` - A [&str] representing the request ID of the initial events request.;
-    ///
-    pub fn remove_events_campaign(&mut self, request_id: &str) {
-        if self.events_senders_map.remove(request_id).is_some() {
-            log::trace!("Removed events campaign with request id: '{request_id}'");
-        }
-    }
-
-    #[doc(hidden)]
-    /// Forwards the log entries to the appropriate log campaign receiver.
-    ///
-    /// ## Arguments
-    ///
-    /// * `request_id` - A [String] representing the request ID of the initial logs request of the log campaign;
-    /// * `log_entries` - A [`Vec<LogEntry>`] containing the log entries of workload to be forwarded;
-    /// * `logs_sender_map` - A [`SynchronizedSenderMap<LogResponse>`] to forward log entries and stop responses for a log campaign.
-    ///
-    async fn forward_log_entries(
-        request_id: String,
-        log_entries: Vec<LogEntry>,
-        logs_sender_map: &SynchronizedSenderMap<LogResponse>,
-    ) {
-        let log_entries_sender = logs_sender_map.get_cloned(&request_id);
-
-        if let Some(sender) = log_entries_sender {
-            log::trace!(
-                "Forwarding log entries for request id '{request_id}' to log campaign receiver."
-            );
-            sender
-                .send(LogResponse::LogEntries(log_entries))
-                .await
-                .unwrap_or_else(|err| {
-                    log::error!("Error while sending log entries: '{err}'");
-                });
-        } else {
-            log::debug!(
-                "Received log entries response for request id '{request_id}', but no log campaign found."
-            );
-        }
-    }
-
-    #[doc(hidden)]
-    /// Forwards the logs stop response for a workload instance to the appropriate log campaign receiver.
-    ///
-    /// ## Arguments
-    ///
-    /// * `request_id` - A [String] representing the request ID of the initial logs request of the log campaign;
-    /// * `instance_name` - A [`WorkloadInstanceName`] for which the logs stop response is sent;
-    /// * `logs_sender_map` - A [`SynchronizedSenderMap<LogResponse>`] to forward log entries and stop responses for a log campaign.
-    ///
-    async fn forward_logs_stop_response(
-        request_id: String,
-        instance_name: WorkloadInstanceName,
-        logs_sender_map: &mut SynchronizedSenderMap<LogResponse>,
-    ) {
-        let log_entries_sender = logs_sender_map.get_cloned(&request_id);
-        if let Some(sender) = log_entries_sender {
-            log::trace!(
-                "Forwarding logs stop response for workload '{instance_name:?}' of request id '{request_id}' to log campaign receiver."
-            );
-            sender
-                .send(LogResponse::LogsStopResponse(instance_name))
-                .await
-                .unwrap_or_else(|err| {
-                    log::error!("Error while sending log stop message: '{err}'");
-                });
-        } else {
-            log::debug!(
-                "Received logs stop response for request id '{request_id}', but no log campaign found."
-            );
-        }
-    }
-
-    #[doc(hidden)]
-    /// Forwards the event entries to the appropriate receiver.
-    ///
-    /// ## Arguments
-    ///
-    /// * `request_id` - A [String] representing the request ID of the initial event request of the events campaign;
-    /// * `event_entry` - A [`EventEntry`] representing the event to be forwarded;
-    /// * `event_sender_map` - A [`SynchronizedSenderMap<EventEntry>`] to forward an event for an event campaign.
-    ///
-    async fn forward_event_response(
-        request_id: String,
-        event_entry: Box<EventEntry>,
-        event_sender_map: &SynchronizedSenderMap<EventEntry>,
-    ) {
-        let event_sender = event_sender_map.get_cloned(&request_id);
-
-        if let Some(sender) = event_sender {
-            log::trace!("Forwarding event entry for request id '{request_id}' to receiver.");
-            sender.send(*event_entry).await.unwrap_or_else(|err| {
-                log::error!("Error while sending event entry: '{err}'");
-            });
-        } else {
-            log::debug!(
-                "Received event entry for request id '{request_id}', but no event campaign found."
-            );
-        }
-    }
-
     /// Prepares and sends a hello to the [Ankaios](https://eclipse-ankaios.github.io/ankaios) cluster.
     ///
     /// ## Arguments
@@ -748,6 +416,128 @@ impl ControlInterface {
             .unwrap_or_else(|err| {
                 log::error!("Error while sending initial hello message: '{err}'");
             });
+    }
+}
+
+#[async_trait]
+impl Connection for ControlInterface {
+    async fn connect(&mut self, timeout: Duration) -> Result<(), AnkaiosError> {
+        if matches!(
+            *self.state.lock().unwrap_or_else(|_| unreachable!()),
+            ControlInterfaceState::Initialized | ControlInterfaceState::Connected
+        ) {
+            return Err(AnkaiosError::ConnectionError(
+                "Already connected.".to_owned(),
+            ));
+        }
+        if metadata(&(self.path.clone() + "/" + ANKAIOS_INPUT_FIFO_PATH)).is_err() {
+            return Err(AnkaiosError::ConnectionError(
+                "Control interface input fifo does not exist.".to_owned(),
+            ));
+        }
+        if metadata(&(self.path.clone() + "/" + ANKAIOS_OUTPUT_FIFO_PATH)).is_err() {
+            return Err(AnkaiosError::ConnectionError(
+                "Control interface output fifo does not exist.".to_owned(),
+            ));
+        }
+
+        self.prepare_writer();
+        self.read_from_control_interface();
+        ControlInterface::change_state(&self.state, ControlInterfaceState::Initialized);
+        ControlInterface::send_initial_hello(
+            self.writer_ch_sender
+                .as_ref()
+                .unwrap_or_else(|| unreachable!()),
+        )
+        .await;
+
+        // Wait for the connection to be established
+        let state_clone = Arc::<Mutex<ControlInterfaceState>>::clone(&self.state);
+        if (tokio_timeout(timeout, async {
+            while *state_clone.lock().unwrap_or_else(|_| unreachable!())
+                != ControlInterfaceState::Connected
+            {
+                sleep(Duration::from_millis(100)).await;
+            }
+        })
+        .await)
+            .is_err()
+        {
+            log::error!("Connection to the control interface timed out.");
+            return Err(AnkaiosError::ConnectionError(
+                "Connection to the control interface timed out.".to_owned(),
+            ));
+        }
+
+        log::trace!("Connected to the control interface.");
+        Ok(())
+    }
+
+    fn disconnect(&mut self) -> Result<(), AnkaiosError> {
+        if !matches!(
+            *self.state.lock().unwrap_or_else(|_| unreachable!()),
+            ControlInterfaceState::Initialized | ControlInterfaceState::Connected
+        ) {
+            return Err(AnkaiosError::ConnectionError(
+                "Already disconnected.".to_owned(),
+            ));
+        }
+        if let Some(handler) = self.read_thread_handler.take() {
+            handler.abort();
+        }
+        self.state
+            .lock()
+            .unwrap_or_else(|_| unreachable!())
+            .clone_from(&ControlInterfaceState::Terminated);
+        self.output_file = None;
+        Ok(())
+    }
+
+    async fn write_request(&mut self, request: AnkaiosRequest) -> Result<(), AnkaiosError> {
+        if *self.state.lock().unwrap_or_else(|_| unreachable!()) != ControlInterfaceState::Connected
+        {
+            log::error!("Could not write to pipe, not connected.");
+            return Err(AnkaiosError::ConnectionError(
+                "Could not write to pipe, not connected.".to_owned(),
+            ));
+        }
+        let message = ToAnkaios {
+            to_ankaios_enum: Some(ToAnkaiosEnum::Request(request)),
+        };
+        if let Some(sender) = self.writer_ch_sender.as_ref() {
+            sender.send(message).await.unwrap_or_else(|err| {
+                log::error!("Error while sending request: '{err}'");
+            });
+        }
+        Ok(())
+    }
+
+    fn add_log_campaign(&mut self, request_id: String, logs_sender: mpsc::Sender<LogResponse>) {
+        log::trace!("Add log campaign with request id: '{request_id}'");
+
+        self.log_senders_map.insert(request_id, logs_sender);
+    }
+
+    fn remove_log_campaign(&mut self, request_id: &str) {
+        if self.log_senders_map.remove(request_id).is_some() {
+            log::trace!("Removed log campaign with request id: '{request_id}'");
+        }
+    }
+
+    fn add_events_campaign(
+        &mut self,
+        request_id: String,
+        events_sender: mpsc::Sender<EventEntry>,
+    ) {
+        log::trace!("Add event campaign with request id: '{request_id}'");
+
+        self.events_senders_map.insert(request_id, events_sender);
+    }
+
+    fn remove_events_campaign(&mut self, request_id: &str) {
+        if self.events_senders_map.remove(request_id).is_some() {
+            log::trace!("Removed events campaign with request id: '{request_id}'");
+        }
     }
 }
 
@@ -780,6 +570,7 @@ mod tests {
         ANKAIOS_INPUT_FIFO_PATH, ANKAIOS_OUTPUT_FIFO_PATH, ANKAIOS_VERSION, ControlInterface,
         ControlInterfaceState, read_protobuf_data,
     };
+    use crate::components::connection::{Connection, forward_log_entries, forward_logs_stop_response};
     use crate::{
         AnkaiosError, EventEntry, LogResponse,
         ankaios::CHANNEL_SIZE,
@@ -952,7 +743,7 @@ mod tests {
         let ret = ci.connect(Duration::from_millis(20)).await;
         assert!(matches!(
             ret,
-            Err(AnkaiosError::ControlInterfaceError(ref msg)) if msg == "Connection to the control interface timed out."
+            Err(AnkaiosError::ConnectionError(ref msg)) if msg == "Connection to the control interface timed out."
         ));
 
         // Disconnect to close the pipes
@@ -986,7 +777,11 @@ mod tests {
         assert_eq!(get_state(&ci), ControlInterfaceState::Terminated);
 
         // Send dummy request - should fail
-        assert!(ci.write_request(generate_test_request()).await.is_err());
+        assert!(
+            ci.write_request(generate_test_request().to_proto())
+                .await
+                .is_err()
+        );
 
         // Create task to simulate the established connection
         let state_clone = Arc::<Mutex<ControlInterfaceState>>::clone(&ci.state);
@@ -1025,7 +820,7 @@ mod tests {
         let req = generate_test_request();
         let req_proto = req.to_proto();
         let req_id = req.get_id();
-        ci.write_request(req).await.unwrap();
+        ci.write_request(req_proto.clone()).await.unwrap();
 
         // Check that the request was sent
         #[allow(clippy::match_wild_err_arm)]
@@ -1335,7 +1130,7 @@ mod tests {
         );
 
         let not_existing_log_request_id = REQUEST_ID_2.to_owned();
-        ControlInterface::forward_log_entries(
+        forward_log_entries(
             not_existing_log_request_id,
             Vec::default(),
             &ci.log_senders_map,
@@ -1445,7 +1240,7 @@ mod tests {
         assert_eq!(ci.log_senders_map.senders_map.lock().unwrap().len(), 1);
 
         let not_existing_log_request_id = REQUEST_ID_2.to_owned();
-        ControlInterface::forward_logs_stop_response(
+        forward_logs_stop_response(
             not_existing_log_request_id,
             WorkloadInstanceName::new(
                 "agent_A".to_owned(),

--- a/src/components/connection/grpc_interface.rs
+++ b/src/components/connection/grpc_interface.rs
@@ -319,17 +319,15 @@ impl GrpcConnection {
 
                 streaming = loop {
                     sleep(Duration::from_millis(RECONNECT_INTERVAL_MILLIS)).await;
-                    if *state.lock().unwrap_or_else(|_| unreachable!())
-                        == GrpcConnectionState::Terminated
-                    {
-                        break 'connection;
-                    }
                     match Self::open_stream(&config).await {
                         Ok((sender, new_streaming)) => {
+                            let mut state_guard = state.lock().unwrap_or_else(|_| unreachable!());
+                            if *state_guard == GrpcConnectionState::Terminated {
+                                break 'connection; // disconnect() won; drop sender/new_streaming
+                            }
                             *writer_ch_sender.lock().unwrap_or_else(|_| unreachable!()) =
                                 Some(sender);
-                            *state.lock().unwrap_or_else(|_| unreachable!()) =
-                                GrpcConnectionState::Connected;
+                            *state_guard = GrpcConnectionState::Connected;
                             log::info!("Reconnected to the Ankaios server.");
                             break new_streaming;
                         }

--- a/src/components/connection/grpc_interface.rs
+++ b/src/components/connection/grpc_interface.rs
@@ -15,7 +15,7 @@
 //! This module contains the [`GrpcConfig`] struct and the gRPC implementation of the
 //! [`Connection`] trait, used to connect to an
 //! [Ankaios](https://eclipse-ankaios.github.io/ankaios) server directly over gRPC, e.g. from
-//! outside a workload.
+//! outside of the cluster.
 
 use async_trait::async_trait;
 use std::sync::{Arc, Mutex};
@@ -39,18 +39,20 @@ use crate::components::response::{Response, ResponseType};
 /// Configuration for connecting to an [Ankaios](https://eclipse-ankaios.github.io/ankaios)
 /// server over gRPC.
 ///
-/// Defaults to an insecure (plaintext) connection; call [`GrpcConfig::tls`] to switch to mTLS.
+/// Constructed either insecure (plaintext, via [`GrpcConfig::insecure`]) or mTLS-secured (via
+/// [`GrpcConfig::mtls`]) — the certificate material is mandatory context for a secured
+/// connection, not an optional add-on, so there is no default-then-upgrade path between the two.
 ///
 /// ## Examples
 ///
 /// ```rust
 /// # use ankaios_sdk::GrpcConfig;
 /// // Insecure connection.
-/// let config = GrpcConfig::new("http://127.0.0.1:25551");
+/// let config = GrpcConfig::insecure("http://127.0.0.1:25551");
 ///
 /// // mTLS connection.
 /// # let (ca_pem, crt_pem, key_pem) = (String::new(), String::new(), String::new());
-/// let config = GrpcConfig::new("https://127.0.0.1:25551").tls(ca_pem, crt_pem, key_pem);
+/// let config = GrpcConfig::mtls("https://127.0.0.1:25551", ca_pem, crt_pem, key_pem);
 /// ```
 #[derive(Clone)]
 pub struct GrpcConfig {
@@ -67,7 +69,8 @@ impl GrpcConfig {
     /// ## Arguments
     ///
     /// * `server_url` - The URL of the Ankaios server, e.g. `http://127.0.0.1:25551`.
-    pub fn new(server_url: impl Into<String>) -> Self {
+    #[must_use]
+    pub fn insecure(server_url: impl Into<String>) -> Self {
         Self {
             server_url: server_url.into(),
             insecure: true,
@@ -77,25 +80,29 @@ impl GrpcConfig {
         }
     }
 
-    /// Switches this configuration to mTLS, using the given PEM-encoded certificate content.
+    /// Creates a new mTLS-secured [`GrpcConfig`] for the given server URL, using the given
+    /// PEM-encoded certificate content.
     ///
     /// ## Arguments
     ///
+    /// * `server_url` - The URL of the Ankaios server, e.g. `https://127.0.0.1:25551`;
     /// * `ca_pem` - The PEM-encoded CA certificate content;
     /// * `crt_pem` - The PEM-encoded client certificate content;
     /// * `key_pem` - The PEM-encoded client private key content.
     #[must_use]
-    pub fn tls(
-        mut self,
+    pub fn mtls(
+        server_url: impl Into<String>,
         ca_pem: impl Into<String>,
         crt_pem: impl Into<String>,
         key_pem: impl Into<String>,
     ) -> Self {
-        self.insecure = false;
-        self.ca_pem = Some(ca_pem.into());
-        self.crt_pem = Some(crt_pem.into());
-        self.key_pem = Some(key_pem.into());
-        self
+        Self {
+            server_url: server_url.into(),
+            insecure: false,
+            ca_pem: Some(ca_pem.into()),
+            crt_pem: Some(crt_pem.into()),
+            key_pem: Some(key_pem.into()),
+        }
     }
 }
 
@@ -127,13 +134,13 @@ pub enum GrpcConnectionState {
 
 /// How long to wait between reconnect attempts once a previously established connection is
 /// lost.
-const RECONNECT_INTERVAL_SECS: u64 = 1;
+const RECONNECT_INTERVAL_MILLIS: u64 = 500;
 
 /// This struct handles the interaction with an [Ankaios](https://eclipse-ankaios.github.io/ankaios)
 /// server over gRPC, playing the commander role via `CommandConnection.ConnectCommand`. The
 /// initial [`connect`](Connection::connect) attempt is never retried. Once a connection has
 /// been successfully established, losing it is treated as transient: the connection is rebuilt
-/// and retried every [`RECONNECT_INTERVAL_SECS`] until it succeeds.
+/// and retried every [`RECONNECT_INTERVAL_MILLIS`] until it succeeds.
 pub struct GrpcConnection {
     /// Configuration used to connect to the Ankaios server.
     config: GrpcConfig,
@@ -189,8 +196,6 @@ impl GrpcConnection {
             plain_endpoint
         } else {
             let ca = Certificate::from_pem(config.ca_pem.as_deref().unwrap_or_default());
-            // `Certificate`/`Identity::from_pem` both accept `impl AsRef<[u8]>`, so the PEM
-            // strings can be passed directly without an intermediate `Certificate::from_pem`.
             let identity = Identity::from_pem(
                 config.crt_pem.as_deref().unwrap_or_default(),
                 config.key_pem.as_deref().unwrap_or_default(),
@@ -266,7 +271,7 @@ impl GrpcConnection {
     /// Spawns the [tokio] task that reads continuously from the gRPC bidi stream. If the
     /// connection is lost after having been established, the task reconnects (rebuilding the
     /// channel, resending [`CommanderHello`] and reopening the stream) every
-    /// [`RECONNECT_INTERVAL_SECS`] until it succeeds or [`disconnect`](Connection::disconnect)
+    /// [`RECONNECT_INTERVAL_MILLIS`] until it succeeds or [`disconnect`](Connection::disconnect)
     /// is called.
     fn spawn_reader_task(&mut self, mut streaming: tonic::Streaming<FromServer>) {
         let config = self.config.clone();
@@ -309,11 +314,11 @@ impl GrpcConnection {
                     *state_guard = GrpcConnectionState::Reconnecting;
                 }
                 log::warn!(
-                    "Lost connection to the Ankaios server, attempting to reconnect every {RECONNECT_INTERVAL_SECS}s..."
+                    "Lost connection to the Ankaios server, attempting to reconnect every {RECONNECT_INTERVAL_MILLIS}ms..."
                 );
 
                 streaming = loop {
-                    sleep(Duration::from_secs(RECONNECT_INTERVAL_SECS)).await;
+                    sleep(Duration::from_millis(RECONNECT_INTERVAL_MILLIS)).await;
                     if *state.lock().unwrap_or_else(|_| unreachable!())
                         == GrpcConnectionState::Terminated
                     {
@@ -354,7 +359,7 @@ impl GrpcConnection {
     ) {
         match from_server.from_server_enum {
             Some(FromServerEnum::Response(response)) => {
-                let received_response = Response::from_ank_base(response);
+                let received_response = Response::from(response);
                 match received_response.content {
                     ResponseType::LogEntriesResponse(log_entries) => {
                         super::forward_log_entries(
@@ -409,18 +414,20 @@ impl GrpcConnection {
 #[async_trait]
 impl Connection for GrpcConnection {
     async fn connect(&mut self, timeout: Duration) -> Result<(), AnkaiosError> {
-        if matches!(
-            *self.state.lock().unwrap_or_else(|_| unreachable!()),
-            GrpcConnectionState::Initialized
-                | GrpcConnectionState::Connected
-                | GrpcConnectionState::Reconnecting
-        ) {
-            return Err(AnkaiosError::ConnectionError(
-                "Already connected.".to_owned(),
-            ));
+        {
+            let mut state_guard = self.state.lock().unwrap_or_else(|_| unreachable!());
+            if matches!(
+                *state_guard,
+                GrpcConnectionState::Initialized
+                    | GrpcConnectionState::Connected
+                    | GrpcConnectionState::Reconnecting
+            ) {
+                return Err(AnkaiosError::ConnectionError(
+                    "Already connected.".to_owned(),
+                ));
+            }
+            *state_guard = GrpcConnectionState::Initialized;
         }
-
-        *self.state.lock().unwrap_or_else(|_| unreachable!()) = GrpcConnectionState::Initialized;
         match tokio_timeout(timeout, self.connect_internal()).await {
             Ok(Ok(())) => {
                 *self.state.lock().unwrap_or_else(|_| unreachable!()) =
@@ -436,14 +443,15 @@ impl Connection for GrpcConnection {
     }
 
     fn disconnect(&mut self) -> Result<(), AnkaiosError> {
-        let mut state_guard = self.state.lock().unwrap_or_else(|_| unreachable!());
-        if *state_guard == GrpcConnectionState::Terminated {
-            return Err(AnkaiosError::ConnectionError(
-                "Already disconnected.".to_owned(),
-            ));
+        {
+            let mut state_guard = self.state.lock().unwrap_or_else(|_| unreachable!());
+            if *state_guard == GrpcConnectionState::Terminated {
+                return Err(AnkaiosError::ConnectionError(
+                    "Already disconnected.".to_owned(),
+                ));
+            }
+            *state_guard = GrpcConnectionState::Terminated;
         }
-        *state_guard = GrpcConnectionState::Terminated;
-        drop(state_guard);
 
         if let Some(handler) = self.reader_task_handle.take() {
             handler.abort();
@@ -528,19 +536,20 @@ mod tests {
     use crate::{AnkaiosError, EventEntry, LogResponse, Response};
 
     const SERVER_URL: &str = "http://127.0.0.1:25551";
+    const REQUEST_ID: &str = "request_id_1";
     const CHANNEL_SIZE: usize = 10;
 
     fn generate_test_grpc_connection() -> (GrpcConnection, mpsc::Receiver<Response>) {
         let (response_sender, response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
         (
-            GrpcConnection::new(GrpcConfig::new(SERVER_URL), response_sender),
+            GrpcConnection::new(GrpcConfig::insecure(SERVER_URL), response_sender),
             response_receiver,
         )
     }
 
     #[test]
     fn utest_grpc_config_without_tls() {
-        let config = GrpcConfig::new(SERVER_URL);
+        let config = GrpcConfig::insecure(SERVER_URL);
 
         assert_eq!(config.server_url, SERVER_URL);
         assert!(config.insecure);
@@ -556,7 +565,7 @@ mod tests {
 
     #[test]
     fn utest_grpc_config_with_tls() {
-        let config = GrpcConfig::new(SERVER_URL).tls("ca-secret", "crt-secret", "key-secret");
+        let config = GrpcConfig::mtls(SERVER_URL, "ca-secret", "crt-secret", "key-secret");
 
         assert_eq!(config.server_url, SERVER_URL);
         assert!(!config.insecure);
@@ -585,7 +594,7 @@ mod tests {
         // Port 0 is never a valid connection target, so this fails fast without needing a
         // real (or even reachable) Ankaios server.
         let mut connection =
-            GrpcConnection::new(GrpcConfig::new("http://127.0.0.1:0"), response_sender);
+            GrpcConnection::new(GrpcConfig::insecure("http://127.0.0.1:0"), response_sender);
 
         let result = connection.connect(Duration::from_secs(5)).await;
         assert!(result.is_err());
@@ -636,24 +645,24 @@ mod tests {
         let (mut connection, _response_receiver) = generate_test_grpc_connection();
         let (logs_sender, _logs_receiver) = mpsc::channel(CHANNEL_SIZE);
 
-        connection.add_log_campaign("request_id_1".to_owned(), logs_sender);
+        connection.add_log_campaign(REQUEST_ID.to_owned(), logs_sender);
         assert!(
             connection
                 .log_senders_map
                 .senders_map
                 .lock()
                 .unwrap()
-                .contains_key("request_id_1")
+                .contains_key(REQUEST_ID)
         );
 
-        connection.remove_log_campaign("request_id_1");
+        connection.remove_log_campaign(REQUEST_ID);
         assert!(
             !connection
                 .log_senders_map
                 .senders_map
                 .lock()
                 .unwrap()
-                .contains_key("request_id_1")
+                .contains_key(REQUEST_ID)
         );
     }
 
@@ -662,24 +671,24 @@ mod tests {
         let (mut connection, _response_receiver) = generate_test_grpc_connection();
         let (events_sender, _events_receiver) = mpsc::channel(CHANNEL_SIZE);
 
-        connection.add_events_campaign("request_id_1".to_owned(), events_sender);
+        connection.add_events_campaign(REQUEST_ID.to_owned(), events_sender);
         assert!(
             connection
                 .events_senders_map
                 .senders_map
                 .lock()
                 .unwrap()
-                .contains_key("request_id_1")
+                .contains_key(REQUEST_ID)
         );
 
-        connection.remove_events_campaign("request_id_1");
+        connection.remove_events_campaign(REQUEST_ID);
         assert!(
             !connection
                 .events_senders_map
                 .senders_map
                 .lock()
                 .unwrap()
-                .contains_key("request_id_1")
+                .contains_key(REQUEST_ID)
         );
     }
 
@@ -688,8 +697,7 @@ mod tests {
         let (connection, mut response_receiver) = generate_test_grpc_connection();
         let mut log_senders_map = connection.log_senders_map.clone();
         let mut events_senders_map = connection.events_senders_map.clone();
-        let ank_base_response =
-            generate_test_ank_base_update_state_success("request_id_1".to_owned());
+        let ank_base_response = generate_test_ank_base_update_state_success(REQUEST_ID.to_owned());
 
         GrpcConnection::handle_decoded_response(
             FromServer {
@@ -705,7 +713,7 @@ mod tests {
             .await
             .expect("response should have been forwarded")
             .expect("channel should not be closed");
-        assert_eq!(result.get_request_id(), "request_id_1");
+        assert_eq!(result.get_request_id(), REQUEST_ID);
     }
 
     #[tokio::test]
@@ -714,10 +722,10 @@ mod tests {
         let mut log_senders_map = connection.log_senders_map.clone();
         let mut events_senders_map = connection.events_senders_map.clone();
         let (logs_sender, mut logs_receiver) = mpsc::channel::<LogResponse>(CHANNEL_SIZE);
-        log_senders_map.insert("request_id_1".to_owned(), logs_sender);
+        log_senders_map.insert(REQUEST_ID.to_owned(), logs_sender);
 
         let ank_base_response = ank_base::Response {
-            request_id: "request_id_1".to_owned(),
+            request_id: REQUEST_ID.to_owned(),
             response_content: Some(AnkaiosResponseContent::LogEntriesResponse(
                 generate_test_proto_log_entries_response(),
             )),
@@ -745,10 +753,10 @@ mod tests {
         let mut log_senders_map = connection.log_senders_map.clone();
         let mut events_senders_map = connection.events_senders_map.clone();
         let (logs_sender, mut logs_receiver) = mpsc::channel::<LogResponse>(CHANNEL_SIZE);
-        log_senders_map.insert("request_id_1".to_owned(), logs_sender);
+        log_senders_map.insert(REQUEST_ID.to_owned(), logs_sender);
 
         let ank_base_response = ank_base::Response {
-            request_id: "request_id_1".to_owned(),
+            request_id: REQUEST_ID.to_owned(),
             response_content: Some(AnkaiosResponseContent::LogsStopResponse(
                 ank_base::LogsStopResponse {
                     workload_name: Some(ank_base::WorkloadInstanceName {
@@ -782,10 +790,10 @@ mod tests {
         let mut log_senders_map = connection.log_senders_map.clone();
         let mut events_senders_map = connection.events_senders_map.clone();
         let (events_sender, mut events_receiver) = mpsc::channel::<EventEntry>(CHANNEL_SIZE);
-        events_senders_map.insert("request_id_1".to_owned(), events_sender);
+        events_senders_map.insert(REQUEST_ID.to_owned(), events_sender);
 
         let ank_base_response = ank_base::Response {
-            request_id: "request_id_1".to_owned(),
+            request_id: REQUEST_ID.to_owned(),
             response_content: Some(AnkaiosResponseContent::CompleteStateResponse(Box::new(
                 ank_base::CompleteStateResponse {
                     complete_state: Some(ank_base::CompleteState::default()),

--- a/src/components/connection/grpc_interface.rs
+++ b/src/components/connection/grpc_interface.rs
@@ -18,6 +18,8 @@
 //! outside of the cluster.
 
 use async_trait::async_trait;
+#[cfg(test)]
+use mockall::automock;
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -160,6 +162,107 @@ pub struct GrpcConnection {
     events_senders_map: SynchronizedSenderMap<EventEntry>,
 }
 
+/// What the reader task needs from a connection: read the next message, or (re)connect. Lets
+/// tests mock the connection instead of needing a real server.
+#[cfg_attr(test, automock)]
+#[async_trait]
+trait ReaderTransport: Send {
+    async fn next_message(&mut self) -> Result<Option<FromServer>, tonic::Status>;
+
+    /// Also used for the initial connect, not just reconnects.
+    async fn attempt_connect(&mut self) -> Result<mpsc::Sender<ToServer>, AnkaiosError>;
+}
+
+/// The real [`ReaderTransport`]. `streaming` is `None` until the first `attempt_connect` call.
+struct GrpcTransport {
+    config: GrpcConfig,
+    streaming: Option<tonic::Streaming<FromServer>>,
+}
+
+#[async_trait]
+impl ReaderTransport for GrpcTransport {
+    async fn next_message(&mut self) -> Result<Option<FromServer>, tonic::Status> {
+        self.streaming
+            .as_mut()
+            .expect("attempt_connect must succeed before next_message is called")
+            .message()
+            .await
+    }
+
+    async fn attempt_connect(&mut self) -> Result<mpsc::Sender<ToServer>, AnkaiosError> {
+        let (sender, streaming) = GrpcConnection::open_stream(&self.config).await?;
+        self.streaming = Some(streaming);
+        Ok(sender)
+    }
+}
+
+/// Reads continuously from `transport`, reconnecting every [`RECONNECT_INTERVAL_MILLIS`] if the
+/// connection is lost, until `state` becomes [`GrpcConnectionState::Terminated`]. A free function
+/// so tests can call it directly instead of through [`tokio::spawn`].
+async fn run_reader_loop<T: ReaderTransport>(
+    mut transport: T,
+    state: Arc<Mutex<GrpcConnectionState>>,
+    writer_ch_sender: Arc<Mutex<Option<mpsc::Sender<ToServer>>>>,
+    response_sender: mpsc::Sender<Response>,
+    mut logs_sender_map: SynchronizedSenderMap<LogResponse>,
+    mut events_sender_map: SynchronizedSenderMap<EventEntry>,
+) {
+    'connection: loop {
+        loop {
+            match transport.next_message().await {
+                Ok(Some(from_server)) => {
+                    GrpcConnection::handle_decoded_response(
+                        from_server,
+                        &response_sender,
+                        &mut logs_sender_map,
+                        &mut events_sender_map,
+                    )
+                    .await;
+                }
+                Ok(None) => {
+                    log::warn!("The gRPC connection to the Ankaios server was closed.");
+                    break;
+                }
+                Err(status) => {
+                    log::error!("Error while reading from the gRPC connection: '{status}'");
+                    break;
+                }
+            }
+        }
+
+        {
+            let mut state_guard = state.lock().unwrap_or_else(|_| unreachable!());
+            if *state_guard == GrpcConnectionState::Terminated {
+                // disconnect() was called; don't try to reconnect.
+                break 'connection;
+            }
+            *state_guard = GrpcConnectionState::Reconnecting;
+        }
+        log::warn!(
+            "Lost connection to the Ankaios server, attempting to reconnect every {RECONNECT_INTERVAL_MILLIS}ms..."
+        );
+
+        loop {
+            sleep(Duration::from_millis(RECONNECT_INTERVAL_MILLIS)).await;
+            match transport.attempt_connect().await {
+                Ok(sender) => {
+                    let mut state_guard = state.lock().unwrap_or_else(|_| unreachable!());
+                    if *state_guard == GrpcConnectionState::Terminated {
+                        break 'connection; // disconnect() won; drop the new sender/stream.
+                    }
+                    *writer_ch_sender.lock().unwrap_or_else(|_| unreachable!()) = Some(sender);
+                    *state_guard = GrpcConnectionState::Connected;
+                    log::info!("Reconnected to the Ankaios server.");
+                    break;
+                }
+                Err(err) => {
+                    log::debug!("Reconnect attempt failed: '{err}'");
+                }
+            }
+        }
+    }
+}
+
 impl GrpcConnection {
     /// Creates a new instance of the gRPC connection.
     ///
@@ -259,85 +362,29 @@ impl GrpcConnection {
     /// `ConnectCommand` bidi stream and spawns the task reading from it (which transparently
     /// reconnects if the connection is later lost).
     async fn connect_internal(&mut self) -> Result<(), AnkaiosError> {
-        let (sender, streaming) = Self::open_stream(&self.config).await?;
+        let mut transport = GrpcTransport {
+            config: self.config.clone(),
+            streaming: None,
+        };
+        let sender = transport.attempt_connect().await?;
         *self
             .writer_ch_sender
             .lock()
             .unwrap_or_else(|_| unreachable!()) = Some(sender);
-        self.spawn_reader_task(streaming);
+        self.spawn_reader_task(transport);
         Ok(())
     }
 
-    /// Spawns the [tokio] task that reads continuously from the gRPC bidi stream. If the
-    /// connection is lost after having been established, the task reconnects (rebuilding the
-    /// channel, resending [`CommanderHello`] and reopening the stream) every
-    /// [`RECONNECT_INTERVAL_MILLIS`] until it succeeds or [`disconnect`](Connection::disconnect)
-    /// is called.
-    fn spawn_reader_task(&mut self, mut streaming: tonic::Streaming<FromServer>) {
-        let config = self.config.clone();
-        let state = Arc::<Mutex<GrpcConnectionState>>::clone(&self.state);
-        let writer_ch_sender = Arc::clone(&self.writer_ch_sender);
-        let response_sender = self.response_sender.clone();
-        let mut logs_sender_map = self.log_senders_map.clone();
-        let mut events_sender_map = self.events_senders_map.clone();
-
-        self.reader_task_handle = Some(tokio::spawn(async move {
-            'connection: loop {
-                loop {
-                    match streaming.message().await {
-                        Ok(Some(from_server)) => {
-                            Self::handle_decoded_response(
-                                from_server,
-                                &response_sender,
-                                &mut logs_sender_map,
-                                &mut events_sender_map,
-                            )
-                            .await;
-                        }
-                        Ok(None) => {
-                            log::warn!("The gRPC connection to the Ankaios server was closed.");
-                            break;
-                        }
-                        Err(status) => {
-                            log::error!("Error while reading from the gRPC connection: '{status}'");
-                            break;
-                        }
-                    }
-                }
-
-                {
-                    let mut state_guard = state.lock().unwrap_or_else(|_| unreachable!());
-                    if *state_guard == GrpcConnectionState::Terminated {
-                        // disconnect() was called; don't try to reconnect.
-                        break 'connection;
-                    }
-                    *state_guard = GrpcConnectionState::Reconnecting;
-                }
-                log::warn!(
-                    "Lost connection to the Ankaios server, attempting to reconnect every {RECONNECT_INTERVAL_MILLIS}ms..."
-                );
-
-                streaming = loop {
-                    sleep(Duration::from_millis(RECONNECT_INTERVAL_MILLIS)).await;
-                    match Self::open_stream(&config).await {
-                        Ok((sender, new_streaming)) => {
-                            let mut state_guard = state.lock().unwrap_or_else(|_| unreachable!());
-                            if *state_guard == GrpcConnectionState::Terminated {
-                                break 'connection; // disconnect() won; drop sender/new_streaming
-                            }
-                            *writer_ch_sender.lock().unwrap_or_else(|_| unreachable!()) =
-                                Some(sender);
-                            *state_guard = GrpcConnectionState::Connected;
-                            log::info!("Reconnected to the Ankaios server.");
-                            break new_streaming;
-                        }
-                        Err(err) => {
-                            log::debug!("Reconnect attempt failed: '{err}'");
-                        }
-                    }
-                };
-            }
-        }));
+    /// Spawns [`run_reader_loop`] as a background task.
+    fn spawn_reader_task<T: ReaderTransport + 'static>(&mut self, transport: T) {
+        self.reader_task_handle = Some(tokio::spawn(run_reader_loop(
+            transport,
+            Arc::clone(&self.state),
+            Arc::clone(&self.writer_ch_sender),
+            self.response_sender.clone(),
+            self.log_senders_map.clone(),
+            self.events_senders_map.clone(),
+        )));
     }
 
     #[doc(hidden)]
@@ -519,12 +566,14 @@ impl Connection for GrpcConnection {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
     use tokio::sync::mpsc;
-    use tokio::time::Duration;
+    use tokio::time::{Duration, sleep};
 
     use super::{
         Connection, FromServer, FromServerEnum, GrpcConfig, GrpcConnection, GrpcConnectionState,
-        ToServer, ToServerEnum,
+        MockReaderTransport, SynchronizedSenderMap, ToServer, ToServerEnum, run_reader_loop,
     };
     use crate::ankaios_api::ank_base::{self, response::ResponseContent as AnkaiosResponseContent};
     use crate::components::request::{Request, generate_test_request};
@@ -861,5 +910,94 @@ mod tests {
         .await;
 
         assert!(response_receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn utest_run_reader_loop_reconnects_after_stream_drop() {
+        let (response_sender, mut response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
+        let state = Arc::new(Mutex::new(GrpcConnectionState::Connected));
+        let writer_ch_sender = Arc::new(Mutex::new(None));
+
+        let mut mock_transport = MockReaderTransport::new();
+        let mut seq = mockall::Sequence::new();
+
+        mock_transport
+            .expect_next_message()
+            .times(1)
+            .in_sequence(&mut seq)
+            .return_once(|| {
+                Ok(Some(FromServer {
+                    from_server_enum: Some(FromServerEnum::Response(
+                        generate_test_ank_base_update_state_success("req_1".to_owned()),
+                    )),
+                }))
+            });
+        mock_transport
+            .expect_next_message()
+            .times(1)
+            .in_sequence(&mut seq)
+            .return_once(|| Err(tonic::Status::unavailable("connection dropped")));
+
+        let (new_sender, _new_receiver) = mpsc::channel::<ToServer>(1);
+        mock_transport
+            .expect_attempt_connect()
+            .times(1)
+            .in_sequence(&mut seq)
+            .return_once(move || Ok(new_sender));
+        // No further expectations on purpose: the next next_message() call panics (harmlessly,
+        // inside the task), freezing state/writer_ch_sender right after reconnecting instead of
+        // racing them.
+
+        let task = tokio::spawn(run_reader_loop(
+            mock_transport,
+            Arc::clone(&state),
+            Arc::clone(&writer_ch_sender),
+            response_sender,
+            SynchronizedSenderMap::default(),
+            SynchronizedSenderMap::default(),
+        ));
+
+        let first = tokio::time::timeout(Duration::from_millis(200), response_receiver.recv())
+            .await
+            .expect("first response should have been forwarded")
+            .expect("channel should not be closed");
+        assert_eq!(first.get_request_id(), "req_1");
+
+        // Give the loop enough headroom to notice the drop, wait RECONNECT_INTERVAL_MILLIS,
+        // reconnect and (harmlessly) panic on the unmocked call after that.
+        sleep(Duration::from_secs(2)).await;
+
+        assert_eq!(*state.lock().unwrap(), GrpcConnectionState::Connected);
+        assert!(writer_ch_sender.lock().unwrap().is_some());
+        assert!(task.is_finished(), "task should have ended (panicked on the unmocked call)");
+    }
+
+    #[tokio::test]
+    async fn utest_run_reader_loop_stops_reconnecting_once_terminated() {
+        let (response_sender, _response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
+        let state = Arc::new(Mutex::new(GrpcConnectionState::Connected));
+        let writer_ch_sender = Arc::new(Mutex::new(None));
+
+        let mut mock_transport = MockReaderTransport::new();
+        // The stream is already gone from the very first read.
+        mock_transport.expect_next_message().returning(|| Ok(None));
+        // attempt_connect() must never be called once disconnect() has set Terminated.
+        mock_transport.expect_attempt_connect().times(0);
+
+        *state.lock().unwrap() = GrpcConnectionState::Terminated;
+
+        let task = tokio::spawn(run_reader_loop(
+            mock_transport,
+            Arc::clone(&state),
+            Arc::clone(&writer_ch_sender),
+            response_sender,
+            SynchronizedSenderMap::default(),
+            SynchronizedSenderMap::default(),
+        ));
+
+        tokio::time::timeout(Duration::from_millis(200), task)
+            .await
+            .expect("loop should exit promptly once state is Terminated")
+            .expect("task should not panic");
     }
 }

--- a/src/components/connection/grpc_interface.rs
+++ b/src/components/connection/grpc_interface.rs
@@ -1,0 +1,870 @@
+// Copyright (c) 2026 Elektrobit Automotive GmbH
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module contains the [`GrpcConfig`] struct and the gRPC implementation of the
+//! [`Connection`] trait, used to connect to an
+//! [Ankaios](https://eclipse-ankaios.github.io/ankaios) server directly over gRPC, e.g. from
+//! outside a workload.
+
+use async_trait::async_trait;
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio::time::{Duration, sleep, timeout as tokio_timeout};
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
+
+use crate::AnkaiosError;
+use crate::ankaios_api::ank_base::Request as AnkaiosRequest;
+use crate::ankaios_api::grpc_api::{
+    CommanderHello, FromServer, ToServer, cli_connection_client::CliConnectionClient,
+    from_server::FromServerEnum, to_server::ToServerEnum,
+};
+use crate::components::connection::{ANKAIOS_VERSION, Connection, SynchronizedSenderMap};
+use crate::components::event_types::EventEntry;
+use crate::components::log_types::LogResponse;
+use crate::components::response::{Response, ResponseType};
+
+/// Configuration for connecting to an [Ankaios](https://eclipse-ankaios.github.io/ankaios)
+/// server over gRPC.
+///
+/// Defaults to an insecure (plaintext) connection; call [`GrpcConfig::tls`] to switch to mTLS.
+///
+/// ## Examples
+///
+/// ```rust
+/// # use ankaios_sdk::GrpcConfig;
+/// // Insecure connection.
+/// let config = GrpcConfig::new("http://127.0.0.1:25551");
+///
+/// // mTLS connection.
+/// # let (ca_pem, crt_pem, key_pem) = (String::new(), String::new(), String::new());
+/// let config = GrpcConfig::new("https://127.0.0.1:25551").tls(ca_pem, crt_pem, key_pem);
+/// ```
+#[derive(Clone)]
+pub struct GrpcConfig {
+    pub(crate) server_url: String,
+    pub(crate) insecure: bool,
+    pub(crate) ca_pem: Option<String>,
+    pub(crate) crt_pem: Option<String>,
+    pub(crate) key_pem: Option<String>,
+}
+
+impl GrpcConfig {
+    /// Creates a new insecure (plaintext) [`GrpcConfig`] for the given server URL.
+    ///
+    /// ## Arguments
+    ///
+    /// * `server_url` - The URL of the Ankaios server, e.g. `http://127.0.0.1:25551`.
+    pub fn new(server_url: impl Into<String>) -> Self {
+        Self {
+            server_url: server_url.into(),
+            insecure: true,
+            ca_pem: None,
+            crt_pem: None,
+            key_pem: None,
+        }
+    }
+
+    /// Switches this configuration to mTLS, using the given PEM-encoded certificate content.
+    ///
+    /// ## Arguments
+    ///
+    /// * `ca_pem` - The PEM-encoded CA certificate content;
+    /// * `crt_pem` - The PEM-encoded client certificate content;
+    /// * `key_pem` - The PEM-encoded client private key content.
+    #[must_use]
+    pub fn tls(
+        mut self,
+        ca_pem: impl Into<String>,
+        crt_pem: impl Into<String>,
+        key_pem: impl Into<String>,
+    ) -> Self {
+        self.insecure = false;
+        self.ca_pem = Some(ca_pem.into());
+        self.crt_pem = Some(crt_pem.into());
+        self.key_pem = Some(key_pem.into());
+        self
+    }
+}
+
+impl std::fmt::Debug for GrpcConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GrpcConfig")
+            .field("server_url", &self.server_url)
+            .field("insecure", &self.insecure)
+            .field("ca_pem", &self.ca_pem.as_ref().map(|_| "<redacted>"))
+            .field("crt_pem", &self.crt_pem.as_ref().map(|_| "<redacted>"))
+            .field("key_pem", &self.key_pem.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
+}
+
+/// Enum representing the state of the [`GrpcConnection`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[repr(i32)]
+pub enum GrpcConnectionState {
+    /// The connection was initialized but not yet accepted by the server.
+    Initialized = 1,
+    /// The connection is established.
+    Connected = 2,
+    /// The connection is terminated.
+    Terminated = 3,
+    /// A previously established connection was lost and is being retried.
+    Reconnecting = 4,
+}
+
+/// How long to wait between reconnect attempts once a previously established connection is
+/// lost.
+const RECONNECT_INTERVAL_SECS: u64 = 1;
+
+/// This struct handles the interaction with an [Ankaios](https://eclipse-ankaios.github.io/ankaios)
+/// server over gRPC, playing the "Cli"/commander role via `CliConnection.ConnectCli`. The
+/// initial [`connect`](Connection::connect) attempt is never retried. Once a connection has
+/// been successfully established, losing it is treated as transient: the connection is rebuilt
+/// and retried every [`RECONNECT_INTERVAL_SECS`] until it succeeds.
+pub struct GrpcConnection {
+    /// Configuration used to connect to the Ankaios server.
+    config: GrpcConfig,
+    /// State of the gRPC connection.
+    state: Arc<Mutex<GrpcConnectionState>>,
+    /// Sender for the outgoing message stream fed into the gRPC bidi call. Shared with the
+    /// reader/reconnect task, which replaces it whenever the connection is rebuilt.
+    writer_ch_sender: Arc<Mutex<Option<mpsc::Sender<ToServer>>>>,
+    /// Handler for the task reading incoming messages from the gRPC bidi stream (and
+    /// transparently reconnecting on a lost connection).
+    reader_task_handle: Option<JoinHandle<()>>,
+    /// Sender for the response channel.
+    response_sender: mpsc::Sender<Response>,
+    /// Request ID to logs sender mapping.
+    log_senders_map: SynchronizedSenderMap<LogResponse>,
+    /// Request ID to events sender mapping.
+    events_senders_map: SynchronizedSenderMap<EventEntry>,
+}
+
+impl GrpcConnection {
+    /// Creates a new instance of the gRPC connection.
+    ///
+    /// ## Arguments
+    ///
+    /// * `config` - The [`GrpcConfig`] to use when connecting;
+    /// * `response_sender` - A sender for the response channel.
+    ///
+    /// ## Returns
+    ///
+    /// A new [`GrpcConnection`] instance.
+    pub fn new(config: GrpcConfig, response_sender: mpsc::Sender<Response>) -> Self {
+        Self {
+            config,
+            state: Arc::new(Mutex::new(GrpcConnectionState::Terminated)),
+            writer_ch_sender: Arc::new(Mutex::new(None)),
+            reader_task_handle: None,
+            response_sender,
+            log_senders_map: SynchronizedSenderMap::default(),
+            events_senders_map: SynchronizedSenderMap::default(),
+        }
+    }
+
+    /// Builds the (optionally mTLS-secured) [`Channel`] used to reach the Ankaios server.
+    async fn build_channel(config: &GrpcConfig) -> Result<Channel, AnkaiosError> {
+        let plain_endpoint = Channel::from_shared(config.server_url.clone()).map_err(|err| {
+            AnkaiosError::ConnectionError(format!(
+                "Invalid gRPC server URL '{}': '{err}'",
+                config.server_url
+            ))
+        })?;
+
+        let endpoint = if config.insecure {
+            plain_endpoint
+        } else {
+            let ca = Certificate::from_pem(config.ca_pem.as_deref().unwrap_or_default());
+            // `Certificate`/`Identity::from_pem` both accept `impl AsRef<[u8]>`, so the PEM
+            // strings can be passed directly without an intermediate `Certificate::from_pem`.
+            let identity = Identity::from_pem(
+                config.crt_pem.as_deref().unwrap_or_default(),
+                config.key_pem.as_deref().unwrap_or_default(),
+            );
+            // Ankaios server certificates are always issued for this domain name, regardless
+            // of the actual connection address.
+            let tls = ClientTlsConfig::new()
+                .domain_name("ank-server")
+                .ca_certificate(ca)
+                .identity(identity);
+
+            plain_endpoint.tls_config(tls).map_err(|err| {
+                AnkaiosError::ConnectionError(format!("Invalid TLS configuration: '{err}'"))
+            })?
+        };
+
+        endpoint.connect().await.map_err(|err| {
+            AnkaiosError::ConnectionError(format!(
+                "Could not connect to the Ankaios server: '{err}'"
+            ))
+        })
+    }
+
+    /// Builds the gRPC channel, sends the initial [`CommanderHello`] and opens the `ConnectCli`
+    /// bidi stream. Used both for the initial connect and for every reconnect attempt.
+    async fn open_stream(
+        config: &GrpcConfig,
+    ) -> Result<(mpsc::Sender<ToServer>, tonic::Streaming<FromServer>), AnkaiosError> {
+        let channel = Self::build_channel(config).await?;
+        let mut client = CliConnectionClient::new(channel);
+
+        let (grpc_tx, grpc_rx) = mpsc::channel::<ToServer>(5);
+        grpc_tx
+            .send(ToServer {
+                to_server_enum: Some(ToServerEnum::CommanderHello(CommanderHello {
+                    protocol_version: ANKAIOS_VERSION.to_owned(),
+                })),
+            })
+            .await
+            .map_err(|err| {
+                AnkaiosError::ConnectionError(format!(
+                    "Error while sending initial hello message: '{err}'"
+                ))
+            })?;
+
+        let streaming = client
+            .connect_cli(ReceiverStream::new(grpc_rx))
+            .await
+            .map_err(|status| {
+                AnkaiosError::ConnectionError(format!(
+                    "Could not connect to the Ankaios server: '{status}'"
+                ))
+            })?
+            .into_inner();
+
+        Ok((grpc_tx, streaming))
+    }
+
+    /// Establishes the gRPC channel, sends the initial [`CommanderHello`], opens the
+    /// `ConnectCli` bidi stream and spawns the task reading from it (which transparently
+    /// reconnects if the connection is later lost).
+    async fn connect_internal(&mut self) -> Result<(), AnkaiosError> {
+        let (sender, streaming) = Self::open_stream(&self.config).await?;
+        *self
+            .writer_ch_sender
+            .lock()
+            .unwrap_or_else(|_| unreachable!()) = Some(sender);
+        self.spawn_reader_task(streaming);
+        Ok(())
+    }
+
+    /// Spawns the [tokio] task that reads continuously from the gRPC bidi stream. If the
+    /// connection is lost after having been established, the task reconnects (rebuilding the
+    /// channel, resending [`CommanderHello`] and reopening the stream) every
+    /// [`RECONNECT_INTERVAL_SECS`] until it succeeds or [`disconnect`](Connection::disconnect)
+    /// is called.
+    fn spawn_reader_task(&mut self, mut streaming: tonic::Streaming<FromServer>) {
+        let config = self.config.clone();
+        let state = Arc::<Mutex<GrpcConnectionState>>::clone(&self.state);
+        let writer_ch_sender = Arc::clone(&self.writer_ch_sender);
+        let response_sender = self.response_sender.clone();
+        let mut logs_sender_map = self.log_senders_map.clone();
+        let mut events_sender_map = self.events_senders_map.clone();
+
+        self.reader_task_handle = Some(tokio::spawn(async move {
+            'connection: loop {
+                loop {
+                    match streaming.message().await {
+                        Ok(Some(from_server)) => {
+                            Self::handle_decoded_response(
+                                from_server,
+                                &response_sender,
+                                &mut logs_sender_map,
+                                &mut events_sender_map,
+                            )
+                            .await;
+                        }
+                        Ok(None) => {
+                            log::warn!("The gRPC connection to the Ankaios server was closed.");
+                            break;
+                        }
+                        Err(status) => {
+                            log::error!("Error while reading from the gRPC connection: '{status}'");
+                            break;
+                        }
+                    }
+                }
+
+                {
+                    let mut state_guard = state.lock().unwrap_or_else(|_| unreachable!());
+                    if *state_guard == GrpcConnectionState::Terminated {
+                        // disconnect() was called; don't try to reconnect.
+                        break 'connection;
+                    }
+                    *state_guard = GrpcConnectionState::Reconnecting;
+                }
+                log::warn!(
+                    "Lost connection to the Ankaios server, attempting to reconnect every {RECONNECT_INTERVAL_SECS}s..."
+                );
+
+                streaming = loop {
+                    sleep(Duration::from_secs(RECONNECT_INTERVAL_SECS)).await;
+                    if *state.lock().unwrap_or_else(|_| unreachable!())
+                        == GrpcConnectionState::Terminated
+                    {
+                        break 'connection;
+                    }
+                    match Self::open_stream(&config).await {
+                        Ok((sender, new_streaming)) => {
+                            *writer_ch_sender.lock().unwrap_or_else(|_| unreachable!()) =
+                                Some(sender);
+                            *state.lock().unwrap_or_else(|_| unreachable!()) =
+                                GrpcConnectionState::Connected;
+                            log::info!("Reconnected to the Ankaios server.");
+                            break new_streaming;
+                        }
+                        Err(err) => {
+                            log::debug!("Reconnect attempt failed: '{err}'");
+                        }
+                    }
+                };
+            }
+        }));
+    }
+
+    #[doc(hidden)]
+    /// Handles a decoded [`FromServer`] message and dispatches to the appropriate action.
+    ///
+    /// ## Arguments
+    ///
+    /// * `from_server` - A decoded [`FromServer`] message from the Ankaios server;
+    /// * `response_sender` - A [`mpsc::Sender<Response>`] to forward generic responses;
+    /// * `logs_sender_map` - A [`SynchronizedSenderMap<LogResponse>`] to forward log entries and stop responses for a log campaign;
+    /// * `events_sender_map` - A [`SynchronizedSenderMap<EventEntry>`] to forward events for an event campaign.
+    async fn handle_decoded_response(
+        from_server: FromServer,
+        response_sender: &mpsc::Sender<Response>,
+        logs_sender_map: &mut SynchronizedSenderMap<LogResponse>,
+        events_sender_map: &mut SynchronizedSenderMap<EventEntry>,
+    ) {
+        match from_server.from_server_enum {
+            Some(FromServerEnum::Response(response)) => {
+                let received_response = Response::from_ank_base(response);
+                match received_response.content {
+                    ResponseType::LogEntriesResponse(log_entries) => {
+                        super::forward_log_entries(
+                            received_response.id,
+                            log_entries,
+                            logs_sender_map,
+                        )
+                        .await;
+                    }
+                    ResponseType::LogsStopResponse(instance_name) => {
+                        super::forward_logs_stop_response(
+                            received_response.id,
+                            instance_name,
+                            logs_sender_map,
+                        )
+                        .await;
+                    }
+                    ResponseType::EventResponse(event_entry) => {
+                        super::forward_event_response(
+                            received_response.id,
+                            event_entry,
+                            events_sender_map,
+                        )
+                        .await;
+                    }
+                    _ => {
+                        response_sender
+                            .send(received_response)
+                            .await
+                            .unwrap_or_else(|err| {
+                                log::error!("Error while sending response: '{err}'");
+                            });
+                    }
+                }
+            }
+            Some(FromServerEnum::ServerHello(_)) => {
+                log::trace!("Received server hello.");
+            }
+            // The server broadcasts this to every commander connection on any workload state
+            // change cluster-wide, not just in response to a request; a commander has no use
+            // for it, but it's expected traffic, not a warning-worthy condition.
+            Some(FromServerEnum::UpdateWorkloadState(_)) => {
+                log::trace!("Ignoring unsolicited workload state update.");
+            }
+            // The server has no way to know which agent still owns a log campaign once it's
+            // cancelled, so it broadcasts this to every connection (agents and commanders
+            // alike) unconditionally, even back to whoever sent the cancel request.
+            Some(FromServerEnum::LogsCancelRequest(_)) => {
+                log::trace!("Ignoring broadcast logs cancel request.");
+            }
+            // The remaining variants (UpdateWorkload, ServerHello handled above, LogsRequest)
+            // are targeted at a specific agent by name and not expected on a commander
+            // connection.
+            Some(other) => {
+                log::warn!("Received unexpected message from the Ankaios server: '{other:?}'");
+            }
+            None => {
+                log::warn!("Received an empty message from the Ankaios server.");
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl Connection for GrpcConnection {
+    async fn connect(&mut self, timeout: Duration) -> Result<(), AnkaiosError> {
+        if matches!(
+            *self.state.lock().unwrap_or_else(|_| unreachable!()),
+            GrpcConnectionState::Initialized
+                | GrpcConnectionState::Connected
+                | GrpcConnectionState::Reconnecting
+        ) {
+            return Err(AnkaiosError::ConnectionError(
+                "Already connected.".to_owned(),
+            ));
+        }
+
+        *self.state.lock().unwrap_or_else(|_| unreachable!()) = GrpcConnectionState::Initialized;
+        match tokio_timeout(timeout, self.connect_internal()).await {
+            Ok(Ok(())) => {
+                *self.state.lock().unwrap_or_else(|_| unreachable!()) =
+                    GrpcConnectionState::Connected;
+                log::trace!("Connected to the Ankaios server over gRPC.");
+                Ok(())
+            }
+            Ok(Err(err)) => Err(err),
+            Err(_) => Err(AnkaiosError::ConnectionError(
+                "Connection to the Ankaios server timed out.".to_owned(),
+            )),
+        }
+    }
+
+    fn disconnect(&mut self) -> Result<(), AnkaiosError> {
+        let mut state_guard = self.state.lock().unwrap_or_else(|_| unreachable!());
+        if *state_guard == GrpcConnectionState::Terminated {
+            return Err(AnkaiosError::ConnectionError(
+                "Already disconnected.".to_owned(),
+            ));
+        }
+        *state_guard = GrpcConnectionState::Terminated;
+        drop(state_guard);
+
+        if let Some(handler) = self.reader_task_handle.take() {
+            handler.abort();
+        }
+        *self
+            .writer_ch_sender
+            .lock()
+            .unwrap_or_else(|_| unreachable!()) = None;
+        Ok(())
+    }
+
+    async fn write_request(&mut self, request: AnkaiosRequest) -> Result<(), AnkaiosError> {
+        if *self.state.lock().unwrap_or_else(|_| unreachable!()) != GrpcConnectionState::Connected {
+            log::error!("Could not write to the gRPC connection, not connected.");
+            return Err(AnkaiosError::ConnectionError(
+                "Could not write to the gRPC connection, not connected.".to_owned(),
+            ));
+        }
+        let maybe_sender = self
+            .writer_ch_sender
+            .lock()
+            .unwrap_or_else(|_| unreachable!())
+            .clone();
+        if let Some(sender) = maybe_sender {
+            sender
+                .send(ToServer {
+                    to_server_enum: Some(ToServerEnum::Request(request)),
+                })
+                .await
+                .unwrap_or_else(|err| {
+                    log::error!("Error while sending request: '{err}'");
+                });
+        }
+        Ok(())
+    }
+
+    fn add_log_campaign(&mut self, request_id: String, logs_sender: mpsc::Sender<LogResponse>) {
+        log::trace!("Add log campaign with request id: '{request_id}'");
+        self.log_senders_map.insert(request_id, logs_sender);
+    }
+
+    fn remove_log_campaign(&mut self, request_id: &str) {
+        if self.log_senders_map.remove(request_id).is_some() {
+            log::trace!("Removed log campaign with request id: '{request_id}'");
+        }
+    }
+
+    fn add_events_campaign(&mut self, request_id: String, events_sender: mpsc::Sender<EventEntry>) {
+        log::trace!("Add event campaign with request id: '{request_id}'");
+        self.events_senders_map.insert(request_id, events_sender);
+    }
+
+    fn remove_events_campaign(&mut self, request_id: &str) {
+        if self.events_senders_map.remove(request_id).is_some() {
+            log::trace!("Removed events campaign with request id: '{request_id}'");
+        }
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//                 ########  #######    #########  #########                //
+//                    ##     ##        ##             ##                    //
+//                    ##     #####     #########      ##                    //
+//                    ##     ##                ##     ##                    //
+//                    ##     #######   #########      ##                    //
+//////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::mpsc;
+    use tokio::time::Duration;
+
+    use super::{
+        Connection, FromServer, FromServerEnum, GrpcConfig, GrpcConnection, GrpcConnectionState,
+        ToServer, ToServerEnum,
+    };
+    use crate::ankaios_api::ank_base::{self, response::ResponseContent as AnkaiosResponseContent};
+    use crate::components::request::{Request, generate_test_request};
+    use crate::components::response::{
+        generate_test_ank_base_update_state_success, generate_test_proto_log_entries_response,
+    };
+    use crate::{AnkaiosError, EventEntry, LogResponse, Response};
+
+    const SERVER_URL: &str = "http://127.0.0.1:25551";
+    const CHANNEL_SIZE: usize = 10;
+
+    fn generate_test_grpc_connection() -> (GrpcConnection, mpsc::Receiver<Response>) {
+        let (response_sender, response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
+        (
+            GrpcConnection::new(GrpcConfig::new(SERVER_URL), response_sender),
+            response_receiver,
+        )
+    }
+
+    #[test]
+    fn utest_grpc_config_without_tls() {
+        let config = GrpcConfig::new(SERVER_URL);
+
+        assert_eq!(config.server_url, SERVER_URL);
+        assert!(config.insecure);
+        assert!(config.ca_pem.is_none());
+        assert!(config.crt_pem.is_none());
+        assert!(config.key_pem.is_none());
+
+        assert_eq!(
+            format!("{config:?}"),
+            "GrpcConfig { server_url: \"http://127.0.0.1:25551\", insecure: true, ca_pem: None, crt_pem: None, key_pem: None }"
+        );
+    }
+
+    #[test]
+    fn utest_grpc_config_with_tls() {
+        let config = GrpcConfig::new(SERVER_URL).tls("ca-secret", "crt-secret", "key-secret");
+
+        assert_eq!(config.server_url, SERVER_URL);
+        assert!(!config.insecure);
+        assert_eq!(config.ca_pem.as_deref(), Some("ca-secret"));
+        assert_eq!(config.crt_pem.as_deref(), Some("crt-secret"));
+        assert_eq!(config.key_pem.as_deref(), Some("key-secret"));
+
+        assert_eq!(
+            format!("{config:?}"),
+            "GrpcConfig { server_url: \"http://127.0.0.1:25551\", insecure: false, ca_pem: Some(\"<redacted>\"), crt_pem: Some(\"<redacted>\"), key_pem: Some(\"<redacted>\") }"
+        );
+    }
+
+    #[tokio::test]
+    async fn utest_grpc_connection_new_starts_terminated() {
+        let (connection, _response_receiver) = generate_test_grpc_connection();
+        assert_eq!(
+            *connection.state.lock().unwrap(),
+            GrpcConnectionState::Terminated
+        );
+    }
+
+    #[tokio::test]
+    async fn utest_grpc_connection_connect_fails_on_unreachable_server() {
+        let (response_sender, _response_receiver) = mpsc::channel::<Response>(CHANNEL_SIZE);
+        // Port 0 is never a valid connection target, so this fails fast without needing a
+        // real (or even reachable) Ankaios server.
+        let mut connection =
+            GrpcConnection::new(GrpcConfig::new("http://127.0.0.1:0"), response_sender);
+
+        let result = connection.connect(Duration::from_secs(5)).await;
+        assert!(result.is_err());
+        assert!(matches!(result, Err(AnkaiosError::ConnectionError(_))));
+        assert_eq!(
+            *connection.state.lock().unwrap(),
+            GrpcConnectionState::Initialized
+        );
+    }
+
+    #[tokio::test]
+    async fn utest_grpc_connection_disconnect_without_connect_fails() {
+        let (mut connection, _response_receiver) = generate_test_grpc_connection();
+        let result = connection.disconnect();
+        assert!(result.is_err());
+        assert!(matches!(result, Err(AnkaiosError::ConnectionError(_))));
+    }
+
+    #[tokio::test]
+    async fn utest_grpc_connection_write_request_fails_when_not_connected() {
+        let (mut connection, _response_receiver) = generate_test_grpc_connection();
+        let result = connection
+            .write_request(crate::ankaios_api::ank_base::Request::default())
+            .await;
+        assert!(result.is_err());
+        assert!(matches!(result, Err(AnkaiosError::ConnectionError(_))));
+    }
+
+    #[tokio::test]
+    async fn utest_grpc_connection_write_request_succeeds_when_connected() {
+        let (mut connection, _response_receiver) = generate_test_grpc_connection();
+        let (grpc_tx, mut grpc_rx) = mpsc::channel::<ToServer>(CHANNEL_SIZE);
+        *connection.writer_ch_sender.lock().unwrap() = Some(grpc_tx);
+        *connection.state.lock().unwrap() = GrpcConnectionState::Connected;
+
+        let request = generate_test_request().to_proto();
+        let result = connection.write_request(request.clone()).await;
+        assert!(result.is_ok());
+
+        let sent = grpc_rx
+            .try_recv()
+            .expect("request should have been written");
+        assert_eq!(sent.to_server_enum, Some(ToServerEnum::Request(request)));
+    }
+
+    #[tokio::test]
+    async fn utest_grpc_connection_log_campaign() {
+        let (mut connection, _response_receiver) = generate_test_grpc_connection();
+        let (logs_sender, _logs_receiver) = mpsc::channel(CHANNEL_SIZE);
+
+        connection.add_log_campaign("request_id_1".to_owned(), logs_sender);
+        assert!(
+            connection
+                .log_senders_map
+                .senders_map
+                .lock()
+                .unwrap()
+                .contains_key("request_id_1")
+        );
+
+        connection.remove_log_campaign("request_id_1");
+        assert!(
+            !connection
+                .log_senders_map
+                .senders_map
+                .lock()
+                .unwrap()
+                .contains_key("request_id_1")
+        );
+    }
+
+    #[tokio::test]
+    async fn utest_grpc_connection_events_campaign() {
+        let (mut connection, _response_receiver) = generate_test_grpc_connection();
+        let (events_sender, _events_receiver) = mpsc::channel(CHANNEL_SIZE);
+
+        connection.add_events_campaign("request_id_1".to_owned(), events_sender);
+        assert!(
+            connection
+                .events_senders_map
+                .senders_map
+                .lock()
+                .unwrap()
+                .contains_key("request_id_1")
+        );
+
+        connection.remove_events_campaign("request_id_1");
+        assert!(
+            !connection
+                .events_senders_map
+                .senders_map
+                .lock()
+                .unwrap()
+                .contains_key("request_id_1")
+        );
+    }
+
+    #[tokio::test]
+    async fn utest_grpc_handle_decoded_response_forwards_generic_response() {
+        let (connection, mut response_receiver) = generate_test_grpc_connection();
+        let mut log_senders_map = connection.log_senders_map.clone();
+        let mut events_senders_map = connection.events_senders_map.clone();
+        let ank_base_response =
+            generate_test_ank_base_update_state_success("request_id_1".to_owned());
+
+        GrpcConnection::handle_decoded_response(
+            FromServer {
+                from_server_enum: Some(FromServerEnum::Response(ank_base_response)),
+            },
+            &connection.response_sender,
+            &mut log_senders_map,
+            &mut events_senders_map,
+        )
+        .await;
+
+        let result = tokio::time::timeout(Duration::from_millis(100), response_receiver.recv())
+            .await
+            .expect("response should have been forwarded")
+            .expect("channel should not be closed");
+        assert_eq!(result.get_request_id(), "request_id_1");
+    }
+
+    #[tokio::test]
+    async fn utest_grpc_handle_decoded_response_forwards_log_entries() {
+        let (connection, _response_receiver) = generate_test_grpc_connection();
+        let mut log_senders_map = connection.log_senders_map.clone();
+        let mut events_senders_map = connection.events_senders_map.clone();
+        let (logs_sender, mut logs_receiver) = mpsc::channel::<LogResponse>(CHANNEL_SIZE);
+        log_senders_map.insert("request_id_1".to_owned(), logs_sender);
+
+        let ank_base_response = ank_base::Response {
+            request_id: "request_id_1".to_owned(),
+            response_content: Some(AnkaiosResponseContent::LogEntriesResponse(
+                generate_test_proto_log_entries_response(),
+            )),
+        };
+
+        GrpcConnection::handle_decoded_response(
+            FromServer {
+                from_server_enum: Some(FromServerEnum::Response(ank_base_response)),
+            },
+            &connection.response_sender,
+            &mut log_senders_map,
+            &mut events_senders_map,
+        )
+        .await;
+
+        let result = tokio::time::timeout(Duration::from_millis(100), logs_receiver.recv())
+            .await
+            .expect("log entries should have been forwarded");
+        assert!(matches!(result, Some(LogResponse::LogEntries(_))));
+    }
+
+    #[tokio::test]
+    async fn utest_grpc_handle_decoded_response_forwards_logs_stop_response() {
+        let (connection, _response_receiver) = generate_test_grpc_connection();
+        let mut log_senders_map = connection.log_senders_map.clone();
+        let mut events_senders_map = connection.events_senders_map.clone();
+        let (logs_sender, mut logs_receiver) = mpsc::channel::<LogResponse>(CHANNEL_SIZE);
+        log_senders_map.insert("request_id_1".to_owned(), logs_sender);
+
+        let ank_base_response = ank_base::Response {
+            request_id: "request_id_1".to_owned(),
+            response_content: Some(AnkaiosResponseContent::LogsStopResponse(
+                ank_base::LogsStopResponse {
+                    workload_name: Some(ank_base::WorkloadInstanceName {
+                        agent_name: "agent_A".to_owned(),
+                        workload_name: "workload_A".to_owned(),
+                        id: "id_a".to_owned(),
+                    }),
+                },
+            )),
+        };
+
+        GrpcConnection::handle_decoded_response(
+            FromServer {
+                from_server_enum: Some(FromServerEnum::Response(ank_base_response)),
+            },
+            &connection.response_sender,
+            &mut log_senders_map,
+            &mut events_senders_map,
+        )
+        .await;
+
+        let result = tokio::time::timeout(Duration::from_millis(100), logs_receiver.recv())
+            .await
+            .expect("logs stop response should have been forwarded");
+        assert!(matches!(result, Some(LogResponse::LogsStopResponse(_))));
+    }
+
+    #[tokio::test]
+    async fn utest_grpc_handle_decoded_response_forwards_event_response() {
+        let (connection, _response_receiver) = generate_test_grpc_connection();
+        let mut log_senders_map = connection.log_senders_map.clone();
+        let mut events_senders_map = connection.events_senders_map.clone();
+        let (events_sender, mut events_receiver) = mpsc::channel::<EventEntry>(CHANNEL_SIZE);
+        events_senders_map.insert("request_id_1".to_owned(), events_sender);
+
+        let ank_base_response = ank_base::Response {
+            request_id: "request_id_1".to_owned(),
+            response_content: Some(AnkaiosResponseContent::CompleteStateResponse(Box::new(
+                ank_base::CompleteStateResponse {
+                    complete_state: Some(ank_base::CompleteState::default()),
+                    altered_fields: Some(ank_base::AlteredFields {
+                        added_fields: vec!["desiredState.workloads.test".to_owned()],
+                        updated_fields: Vec::default(),
+                        removed_fields: Vec::default(),
+                    }),
+                },
+            ))),
+        };
+
+        GrpcConnection::handle_decoded_response(
+            FromServer {
+                from_server_enum: Some(FromServerEnum::Response(ank_base_response)),
+            },
+            &connection.response_sender,
+            &mut log_senders_map,
+            &mut events_senders_map,
+        )
+        .await;
+
+        let event = tokio::time::timeout(Duration::from_millis(100), events_receiver.recv())
+            .await
+            .expect("event should have been forwarded")
+            .expect("channel should not be closed");
+        assert_eq!(
+            event.added_fields,
+            vec!["desiredState.workloads.test".to_owned()]
+        );
+    }
+
+    #[tokio::test]
+    async fn utest_grpc_handle_decoded_response_ignores_non_response_messages() {
+        let (connection, mut response_receiver) = generate_test_grpc_connection();
+        let mut log_senders_map = connection.log_senders_map.clone();
+        let mut events_senders_map = connection.events_senders_map.clone();
+
+        for from_server_enum in [
+            FromServerEnum::ServerHello(crate::ankaios_api::grpc_api::ServerHello::default()),
+            FromServerEnum::UpdateWorkloadState(
+                crate::ankaios_api::grpc_api::UpdateWorkloadState::default(),
+            ),
+            FromServerEnum::LogsCancelRequest(
+                crate::ankaios_api::grpc_api::LogsCancelRequest::default(),
+            ),
+            FromServerEnum::UpdateWorkload(crate::ankaios_api::grpc_api::UpdateWorkload::default()),
+        ] {
+            GrpcConnection::handle_decoded_response(
+                FromServer {
+                    from_server_enum: Some(from_server_enum),
+                },
+                &connection.response_sender,
+                &mut log_senders_map,
+                &mut events_senders_map,
+            )
+            .await;
+        }
+        GrpcConnection::handle_decoded_response(
+            FromServer {
+                from_server_enum: None,
+            },
+            &connection.response_sender,
+            &mut log_senders_map,
+            &mut events_senders_map,
+        )
+        .await;
+
+        assert!(response_receiver.try_recv().is_err());
+    }
+}

--- a/src/components/connection/grpc_interface.rs
+++ b/src/components/connection/grpc_interface.rs
@@ -28,7 +28,7 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
 use crate::AnkaiosError;
 use crate::ankaios_api::ank_base::Request as AnkaiosRequest;
 use crate::ankaios_api::grpc_api::{
-    CommanderHello, FromServer, ToServer, cli_connection_client::CliConnectionClient,
+    CommanderHello, FromServer, ToServer, command_connection_client::CommandConnectionClient,
     from_server::FromServerEnum, to_server::ToServerEnum,
 };
 use crate::components::connection::{ANKAIOS_VERSION, Connection, SynchronizedSenderMap};
@@ -130,7 +130,7 @@ pub enum GrpcConnectionState {
 const RECONNECT_INTERVAL_SECS: u64 = 1;
 
 /// This struct handles the interaction with an [Ankaios](https://eclipse-ankaios.github.io/ankaios)
-/// server over gRPC, playing the "Cli"/commander role via `CliConnection.ConnectCli`. The
+/// server over gRPC, playing the commander role via `CommandConnection.ConnectCommand`. The
 /// initial [`connect`](Connection::connect) attempt is never retried. Once a connection has
 /// been successfully established, losing it is treated as transient: the connection is rebuilt
 /// and retried every [`RECONNECT_INTERVAL_SECS`] until it succeeds.
@@ -214,13 +214,14 @@ impl GrpcConnection {
         })
     }
 
-    /// Builds the gRPC channel, sends the initial [`CommanderHello`] and opens the `ConnectCli`
-    /// bidi stream. Used both for the initial connect and for every reconnect attempt.
+    /// Builds the gRPC channel, sends the initial [`CommanderHello`] and opens the
+    /// `ConnectCommand` bidi stream. Used both for the initial connect and for every reconnect
+    /// attempt.
     async fn open_stream(
         config: &GrpcConfig,
     ) -> Result<(mpsc::Sender<ToServer>, tonic::Streaming<FromServer>), AnkaiosError> {
         let channel = Self::build_channel(config).await?;
-        let mut client = CliConnectionClient::new(channel);
+        let mut client = CommandConnectionClient::new(channel);
 
         let (grpc_tx, grpc_rx) = mpsc::channel::<ToServer>(5);
         grpc_tx
@@ -237,7 +238,7 @@ impl GrpcConnection {
             })?;
 
         let streaming = client
-            .connect_cli(ReceiverStream::new(grpc_rx))
+            .connect_command(ReceiverStream::new(grpc_rx))
             .await
             .map_err(|status| {
                 AnkaiosError::ConnectionError(format!(
@@ -250,7 +251,7 @@ impl GrpcConnection {
     }
 
     /// Establishes the gRPC channel, sends the initial [`CommanderHello`], opens the
-    /// `ConnectCli` bidi stream and spawns the task reading from it (which transparently
+    /// `ConnectCommand` bidi stream and spawns the task reading from it (which transparently
     /// reconnects if the connection is later lost).
     async fn connect_internal(&mut self) -> Result<(), AnkaiosError> {
         let (sender, streaming) = Self::open_stream(&self.config).await?;
@@ -392,21 +393,9 @@ impl GrpcConnection {
             Some(FromServerEnum::ServerHello(_)) => {
                 log::trace!("Received server hello.");
             }
-            // The server broadcasts this to every commander connection on any workload state
-            // change cluster-wide, not just in response to a request; a commander has no use
-            // for it, but it's expected traffic, not a warning-worthy condition.
-            Some(FromServerEnum::UpdateWorkloadState(_)) => {
-                log::trace!("Ignoring unsolicited workload state update.");
-            }
-            // The server has no way to know which agent still owns a log campaign once it's
-            // cancelled, so it broadcasts this to every connection (agents and commanders
-            // alike) unconditionally, even back to whoever sent the cancel request.
-            Some(FromServerEnum::LogsCancelRequest(_)) => {
-                log::trace!("Ignoring broadcast logs cancel request.");
-            }
-            // The remaining variants (UpdateWorkload, ServerHello handled above, LogsRequest)
-            // are targeted at a specific agent by name and not expected on a commander
-            // connection.
+            // The remaining variants (UpdateWorkload, UpdateWorkloadState, LogsRequest,
+            // LogsCancelRequest) are targeted at a specific agent by name and not expected on a
+            // `CommandConnection`.
             Some(other) => {
                 log::warn!("Received unexpected message from the Ankaios server: '{other:?}'");
             }

--- a/src/components/connection/helpers.rs
+++ b/src/components/connection/helpers.rs
@@ -12,45 +12,30 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! This module contains the [`Connection`] trait, which abstracts over the different ways
-//! this SDK can talk to [Ankaios]: the always-available control interface (named pipes, used
-//! from inside a workload) and, behind the `grpc` feature, a direct gRPC connection to the
-//! Ankaios server (used from outside a workload).
-//!
-//! [Ankaios]: https://eclipse-ankaios.github.io/ankaios
+//! This module contains helpers shared by every [`Connection`](super::Connection)
+//! implementation: [`RequestId`], [`SynchronizedSenderMap`], and the `forward_*` functions used
+//! to dispatch log/event campaign messages to their receiver.
 
-use async_trait::async_trait;
-#[cfg(test)]
-use mockall::automock;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
-use tokio::time::Duration;
 
-use crate::AnkaiosError;
-use crate::ankaios_api::ank_base::Request as AnkaiosRequest;
 use crate::components::event_types::EventEntry;
 use crate::components::log_types::{LogEntry, LogResponse};
 use crate::components::workload_state_mod::WorkloadInstanceName;
 
-#[cfg(feature = "control_interface")]
-pub mod control_interface;
-#[cfg(feature = "grpc_server_interface")]
-pub mod grpc_interface;
-
-/// Version of [Ankaios](https://eclipse-ankaios.github.io/ankaios) that is compatible with this
-/// SDK, sent as part of every connection handshake (control interface or gRPC), regardless of
-/// transport.
-pub(crate) const ANKAIOS_VERSION: &str = "1.0.0";
+/// The ID of a [`Request`](crate::Request), used to match it to its response and, for log/event
+/// campaigns, to the ongoing campaign it belongs to.
+pub(crate) type RequestId = String;
 
 /// Maps request IDs to the sender half of a channel used to forward messages for an ongoing
-/// log or event campaign. Shared infrastructure for any [`Connection`] implementation that
-/// supports streaming campaigns (log entries, events) keyed by request ID.
+/// log or event campaign. Shared infrastructure for any [`Connection`](super::Connection)
+/// implementation that supports streaming campaigns (log entries, events) keyed by request ID.
 #[doc(hidden)]
 #[derive(Debug, Clone)]
 pub(crate) struct SynchronizedSenderMap<T> {
-    /// A map of request IDs to their corresponding senders.
-    pub(crate) senders_map: Arc<Mutex<HashMap<String, mpsc::Sender<T>>>>,
+    /// Maps a campaign's request ID to its sender.
+    pub(crate) senders_map: Arc<Mutex<HashMap<RequestId, mpsc::Sender<T>>>>,
 }
 
 impl<T> SynchronizedSenderMap<T> {
@@ -58,10 +43,10 @@ impl<T> SynchronizedSenderMap<T> {
     ///
     /// ## Arguments
     ///
-    /// * `request_id` - A [String] representing the request ID;
+    /// * `request_id` - The [`RequestId`] of the campaign;
     /// * `sender` - A [`mpsc::Sender<T>`] to forward campaign messages.
     ///
-    pub(crate) fn insert(&mut self, request_id: String, sender: mpsc::Sender<T>) {
+    pub(crate) fn insert(&mut self, request_id: RequestId, sender: mpsc::Sender<T>) {
         self.senders_map
             .lock()
             .unwrap_or_else(|_| unreachable!())
@@ -72,11 +57,11 @@ impl<T> SynchronizedSenderMap<T> {
     ///
     /// ## Arguments
     ///
-    /// * `request_id` - A [String] representing the request ID.
+    /// * `request_id` - The [`RequestId`] of the campaign.
     ///
     /// ## Returns
     ///
-    /// An [`Option<mpsc::Sender<T>>`] if the request ID was found and removed, otherwise `None`.
+    /// An [`mpsc::Sender<T>`] if the request ID was found and removed, otherwise `None`.
     pub(crate) fn remove(&mut self, request_id: &str) -> Option<mpsc::Sender<T>> {
         self.senders_map
             .lock()
@@ -88,7 +73,7 @@ impl<T> SynchronizedSenderMap<T> {
     ///
     /// ## Arguments
     ///
-    /// * `request_id` - A [String] representing the request ID.
+    /// * `request_id` - The [`RequestId`] of the campaign.
     ///
     /// ## Returns
     ///
@@ -111,17 +96,17 @@ impl<T> Default for SynchronizedSenderMap<T> {
 }
 
 /// Forwards the log entries to the appropriate log campaign receiver. Shared by every
-/// [`Connection`] implementation's response dispatch, since it operates purely on the already
-/// envelope-decoded [`LogEntry`] payload.
+/// [`Connection`](super::Connection) implementation's response dispatch, since it operates
+/// purely on the already envelope-decoded [`LogEntry`] payload.
 ///
 /// ## Arguments
 ///
-/// * `request_id` - A [String] representing the request ID of the initial logs request of the log campaign;
+/// * `request_id` - The [`RequestId`] of the initial logs request of the log campaign;
 /// * `log_entries` - A [`Vec<LogEntry>`] containing the log entries of workload to be forwarded;
 /// * `logs_sender_map` - A [`SynchronizedSenderMap<LogResponse>`] to forward log entries and stop responses for a log campaign.
 ///
 pub(crate) async fn forward_log_entries(
-    request_id: String,
+    request_id: RequestId,
     log_entries: Vec<LogEntry>,
     logs_sender_map: &SynchronizedSenderMap<LogResponse>,
 ) {
@@ -145,16 +130,17 @@ pub(crate) async fn forward_log_entries(
 }
 
 /// Forwards the logs stop response for a workload instance to the appropriate log campaign
-/// receiver. Shared by every [`Connection`] implementation's response dispatch.
+/// receiver. Shared by every [`Connection`](super::Connection) implementation's response
+/// dispatch.
 ///
 /// ## Arguments
 ///
-/// * `request_id` - A [String] representing the request ID of the initial logs request of the log campaign;
+/// * `request_id` - The [`RequestId`] of the initial logs request of the log campaign;
 /// * `instance_name` - A [`WorkloadInstanceName`] for which the logs stop response is sent;
 /// * `logs_sender_map` - A [`SynchronizedSenderMap<LogResponse>`] to forward log entries and stop responses for a log campaign.
 ///
 pub(crate) async fn forward_logs_stop_response(
-    request_id: String,
+    request_id: RequestId,
     instance_name: WorkloadInstanceName,
     logs_sender_map: &mut SynchronizedSenderMap<LogResponse>,
 ) {
@@ -176,17 +162,17 @@ pub(crate) async fn forward_logs_stop_response(
     }
 }
 
-/// Forwards the event entries to the appropriate receiver. Shared by every [`Connection`]
-/// implementation's response dispatch.
+/// Forwards the event entries to the appropriate receiver. Shared by every
+/// [`Connection`](super::Connection) implementation's response dispatch.
 ///
 /// ## Arguments
 ///
-/// * `request_id` - A [String] representing the request ID of the initial event request of the events campaign;
+/// * `request_id` - The [`RequestId`] of the initial event request of the events campaign;
 /// * `event_entry` - A [`EventEntry`] representing the event to be forwarded;
 /// * `event_sender_map` - A [`SynchronizedSenderMap<EventEntry>`] to forward an event for an event campaign.
 ///
 pub(crate) async fn forward_event_response(
-    request_id: String,
+    request_id: RequestId,
     event_entry: Box<EventEntry>,
     event_sender_map: &SynchronizedSenderMap<EventEntry>,
 ) {
@@ -202,35 +188,6 @@ pub(crate) async fn forward_event_response(
             "Received event entry for request id '{request_id}', but no event campaign found."
         );
     }
-}
-
-/// Abstracts over the transport used to exchange [`AnkaiosRequest`]/[`Response`](crate::Response)
-/// messages with Ankaios, so that [`Ankaios`](crate::Ankaios) can work identically regardless of
-/// whether it is connected via the control interface or via gRPC.
-#[cfg_attr(test, automock)]
-#[async_trait]
-pub(crate) trait Connection: Send {
-    /// Establishes the connection, waiting up to `timeout` for it to be accepted.
-    async fn connect(&mut self, timeout: Duration) -> Result<(), AnkaiosError>;
-
-    /// Tears down the connection.
-    fn disconnect(&mut self) -> Result<(), AnkaiosError>;
-
-    /// Sends a request. The request must already have been converted to its proto
-    /// representation via [`Request::to_proto`](crate::Request::to_proto).
-    async fn write_request(&mut self, request: AnkaiosRequest) -> Result<(), AnkaiosError>;
-
-    /// Registers a channel to receive log entries for an ongoing log campaign.
-    fn add_log_campaign(&mut self, request_id: String, logs_sender: mpsc::Sender<LogResponse>);
-
-    /// Unregisters a log campaign started via [`add_log_campaign`](Connection::add_log_campaign).
-    fn remove_log_campaign(&mut self, request_id: &str);
-
-    /// Registers a channel to receive events for an ongoing event campaign.
-    fn add_events_campaign(&mut self, request_id: String, events_sender: mpsc::Sender<EventEntry>);
-
-    /// Unregisters an event campaign started via [`add_events_campaign`](Connection::add_events_campaign).
-    fn remove_events_campaign(&mut self, request_id: &str);
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/components/connection/mod.rs
+++ b/src/components/connection/mod.rs
@@ -1,0 +1,299 @@
+// Copyright (c) 2026 Elektrobit Automotive GmbH
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module contains the [`Connection`] trait, which abstracts over the different ways
+//! this SDK can talk to [Ankaios]: the always-available control interface (named pipes, used
+//! from inside a workload) and, behind the `grpc` feature, a direct gRPC connection to the
+//! Ankaios server (used from outside a workload).
+//!
+//! [Ankaios]: https://eclipse-ankaios.github.io/ankaios
+
+use async_trait::async_trait;
+#[cfg(test)]
+use mockall::automock;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+use tokio::time::Duration;
+
+use crate::AnkaiosError;
+use crate::ankaios_api::ank_base::Request as AnkaiosRequest;
+use crate::components::event_types::EventEntry;
+use crate::components::log_types::{LogEntry, LogResponse};
+use crate::components::workload_state_mod::WorkloadInstanceName;
+
+#[cfg(feature = "control_interface")]
+pub mod control_interface;
+#[cfg(feature = "grpc_server_interface")]
+pub mod grpc_interface;
+
+/// Version of [Ankaios](https://eclipse-ankaios.github.io/ankaios) that is compatible with this
+/// SDK, sent as part of every connection handshake (control interface or gRPC), regardless of
+/// transport.
+pub(crate) const ANKAIOS_VERSION: &str = "1.0.0";
+
+/// Maps request IDs to the sender half of a channel used to forward messages for an ongoing
+/// log or event campaign. Shared infrastructure for any [`Connection`] implementation that
+/// supports streaming campaigns (log entries, events) keyed by request ID.
+#[doc(hidden)]
+#[derive(Debug, Clone)]
+pub(crate) struct SynchronizedSenderMap<T> {
+    /// A map of request IDs to their corresponding senders.
+    pub(crate) senders_map: Arc<Mutex<HashMap<String, mpsc::Sender<T>>>>,
+}
+
+impl<T> SynchronizedSenderMap<T> {
+    /// Inserts a new sender for a request ID part of a started campaign.
+    ///
+    /// ## Arguments
+    ///
+    /// * `request_id` - A [String] representing the request ID;
+    /// * `sender` - A [`mpsc::Sender<T>`] to forward campaign messages.
+    ///
+    pub(crate) fn insert(&mut self, request_id: String, sender: mpsc::Sender<T>) {
+        self.senders_map
+            .lock()
+            .unwrap_or_else(|_| unreachable!())
+            .insert(request_id, sender);
+    }
+
+    /// Removes a sender by its request ID.
+    ///
+    /// ## Arguments
+    ///
+    /// * `request_id` - A [String] representing the request ID.
+    ///
+    /// ## Returns
+    ///
+    /// An [`Option<mpsc::Sender<T>>`] if the request ID was found and removed, otherwise `None`.
+    pub(crate) fn remove(&mut self, request_id: &str) -> Option<mpsc::Sender<T>> {
+        self.senders_map
+            .lock()
+            .unwrap_or_else(|_| unreachable!())
+            .remove(request_id)
+    }
+
+    /// Gets a cloned sender by its request ID.
+    ///
+    /// ## Arguments
+    ///
+    /// * `request_id` - A [String] representing the request ID.
+    ///
+    /// ## Returns
+    ///
+    /// An [`Option<mpsc::Sender<T>>`] if the request ID was found, otherwise `None`.
+    pub(crate) fn get_cloned(&self, request_id: &str) -> Option<mpsc::Sender<T>> {
+        self.senders_map
+            .lock()
+            .unwrap_or_else(|_| unreachable!())
+            .get(request_id)
+            .cloned()
+    }
+}
+
+impl<T> Default for SynchronizedSenderMap<T> {
+    fn default() -> Self {
+        SynchronizedSenderMap {
+            senders_map: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+/// Forwards the log entries to the appropriate log campaign receiver. Shared by every
+/// [`Connection`] implementation's response dispatch, since it operates purely on the already
+/// envelope-decoded [`LogEntry`] payload.
+///
+/// ## Arguments
+///
+/// * `request_id` - A [String] representing the request ID of the initial logs request of the log campaign;
+/// * `log_entries` - A [`Vec<LogEntry>`] containing the log entries of workload to be forwarded;
+/// * `logs_sender_map` - A [`SynchronizedSenderMap<LogResponse>`] to forward log entries and stop responses for a log campaign.
+///
+pub(crate) async fn forward_log_entries(
+    request_id: String,
+    log_entries: Vec<LogEntry>,
+    logs_sender_map: &SynchronizedSenderMap<LogResponse>,
+) {
+    let log_entries_sender = logs_sender_map.get_cloned(&request_id);
+
+    if let Some(sender) = log_entries_sender {
+        log::trace!(
+            "Forwarding log entries for request id '{request_id}' to log campaign receiver."
+        );
+        sender
+            .send(LogResponse::LogEntries(log_entries))
+            .await
+            .unwrap_or_else(|err| {
+                log::error!("Error while sending log entries: '{err}'");
+            });
+    } else {
+        log::debug!(
+            "Received log entries response for request id '{request_id}', but no log campaign found."
+        );
+    }
+}
+
+/// Forwards the logs stop response for a workload instance to the appropriate log campaign
+/// receiver. Shared by every [`Connection`] implementation's response dispatch.
+///
+/// ## Arguments
+///
+/// * `request_id` - A [String] representing the request ID of the initial logs request of the log campaign;
+/// * `instance_name` - A [`WorkloadInstanceName`] for which the logs stop response is sent;
+/// * `logs_sender_map` - A [`SynchronizedSenderMap<LogResponse>`] to forward log entries and stop responses for a log campaign.
+///
+pub(crate) async fn forward_logs_stop_response(
+    request_id: String,
+    instance_name: WorkloadInstanceName,
+    logs_sender_map: &mut SynchronizedSenderMap<LogResponse>,
+) {
+    let log_entries_sender = logs_sender_map.get_cloned(&request_id);
+    if let Some(sender) = log_entries_sender {
+        log::trace!(
+            "Forwarding logs stop response for workload '{instance_name:?}' of request id '{request_id}' to log campaign receiver."
+        );
+        sender
+            .send(LogResponse::LogsStopResponse(instance_name))
+            .await
+            .unwrap_or_else(|err| {
+                log::error!("Error while sending log stop message: '{err}'");
+            });
+    } else {
+        log::debug!(
+            "Received logs stop response for request id '{request_id}', but no log campaign found."
+        );
+    }
+}
+
+/// Forwards the event entries to the appropriate receiver. Shared by every [`Connection`]
+/// implementation's response dispatch.
+///
+/// ## Arguments
+///
+/// * `request_id` - A [String] representing the request ID of the initial event request of the events campaign;
+/// * `event_entry` - A [`EventEntry`] representing the event to be forwarded;
+/// * `event_sender_map` - A [`SynchronizedSenderMap<EventEntry>`] to forward an event for an event campaign.
+///
+pub(crate) async fn forward_event_response(
+    request_id: String,
+    event_entry: Box<EventEntry>,
+    event_sender_map: &SynchronizedSenderMap<EventEntry>,
+) {
+    let event_sender = event_sender_map.get_cloned(&request_id);
+
+    if let Some(sender) = event_sender {
+        log::trace!("Forwarding event entry for request id '{request_id}' to receiver.");
+        sender.send(*event_entry).await.unwrap_or_else(|err| {
+            log::error!("Error while sending event entry: '{err}'");
+        });
+    } else {
+        log::debug!(
+            "Received event entry for request id '{request_id}', but no event campaign found."
+        );
+    }
+}
+
+/// Abstracts over the transport used to exchange [`AnkaiosRequest`]/[`Response`](crate::Response)
+/// messages with Ankaios, so that [`Ankaios`](crate::Ankaios) can work identically regardless of
+/// whether it is connected via the control interface or via gRPC.
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub(crate) trait Connection: Send {
+    /// Establishes the connection, waiting up to `timeout` for it to be accepted.
+    async fn connect(&mut self, timeout: Duration) -> Result<(), AnkaiosError>;
+
+    /// Tears down the connection.
+    fn disconnect(&mut self) -> Result<(), AnkaiosError>;
+
+    /// Sends a request. The request must already have been converted to its proto
+    /// representation via [`Request::to_proto`](crate::Request::to_proto).
+    async fn write_request(&mut self, request: AnkaiosRequest) -> Result<(), AnkaiosError>;
+
+    /// Registers a channel to receive log entries for an ongoing log campaign.
+    fn add_log_campaign(&mut self, request_id: String, logs_sender: mpsc::Sender<LogResponse>);
+
+    /// Unregisters a log campaign started via [`add_log_campaign`](Connection::add_log_campaign).
+    fn remove_log_campaign(&mut self, request_id: &str);
+
+    /// Registers a channel to receive events for an ongoing event campaign.
+    fn add_events_campaign(&mut self, request_id: String, events_sender: mpsc::Sender<EventEntry>);
+
+    /// Unregisters an event campaign started via [`add_events_campaign`](Connection::add_events_campaign).
+    fn remove_events_campaign(&mut self, request_id: &str);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//                 ########  #######    #########  #########                //
+//                    ##     ##        ##             ##                    //
+//                    ##     #####     #########      ##                    //
+//                    ##     ##                ##     ##                    //
+//                    ##     #######   #########      ##                    //
+//////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::mpsc;
+
+    use super::{
+        SynchronizedSenderMap, forward_event_response, forward_log_entries,
+        forward_logs_stop_response,
+    };
+    use crate::components::event_types::EventEntry;
+    use crate::components::log_types::LogResponse;
+    use crate::components::workload_state_mod::WorkloadInstanceName;
+
+    const REQUEST_ID: &str = "request_id_1";
+
+    // A dropped receiver makes the forwarding send() fail; these tests only check that the
+    // failure is swallowed (logged) instead of panicking.
+
+    #[tokio::test]
+    async fn utest_forward_log_entries_survives_dropped_receiver() {
+        let mut map = SynchronizedSenderMap::<LogResponse>::default();
+        let (sender, receiver) = mpsc::channel(1);
+        map.insert(REQUEST_ID.to_owned(), sender);
+        drop(receiver);
+
+        forward_log_entries(REQUEST_ID.to_owned(), Vec::default(), &map).await;
+    }
+
+    #[tokio::test]
+    async fn utest_forward_logs_stop_response_survives_dropped_receiver() {
+        let mut map = SynchronizedSenderMap::<LogResponse>::default();
+        let (sender, receiver) = mpsc::channel(1);
+        map.insert(REQUEST_ID.to_owned(), sender);
+        drop(receiver);
+
+        forward_logs_stop_response(
+            REQUEST_ID.to_owned(),
+            WorkloadInstanceName::new(
+                "agent_A".to_owned(),
+                "workload_A".to_owned(),
+                "id_a".to_owned(),
+            ),
+            &mut map,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn utest_forward_event_response_survives_dropped_receiver() {
+        let mut map = SynchronizedSenderMap::<EventEntry>::default();
+        let (sender, receiver) = mpsc::channel(1);
+        map.insert(REQUEST_ID.to_owned(), sender);
+        drop(receiver);
+
+        forward_event_response(REQUEST_ID.to_owned(), Box::default(), &map).await;
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -18,7 +18,7 @@
 //! [Ankaios]: https://eclipse-ankaios.github.io/ankaios
 
 pub mod complete_state;
-pub mod control_interface;
+pub mod connection;
 pub mod event_types;
 pub mod log_types;
 pub mod manifest;

--- a/src/components/response.rs
+++ b/src/components/response.rs
@@ -54,9 +54,10 @@ use crate::components::event_types::EventEntry;
 use crate::components::log_types::LogEntry;
 use crate::extensions::UnreachableOption;
 use ankaios_api::ank_base::{
-    Error, UpdateStateSuccess as AnkaiosUpdateStateSuccess,
+    Error, Response as AnkaiosResponse, UpdateStateSuccess as AnkaiosUpdateStateSuccess,
     response::ResponseContent as AnkaiosResponseContent,
 };
+#[cfg(feature = "control_interface")]
 use ankaios_api::control_api::{FromAnkaios, from_ankaios::FromAnkaiosEnum};
 use std::collections::HashMap;
 use std::default;
@@ -73,6 +74,7 @@ pub enum ResponseType {
     /// An error provided by the cluster.
     Error(String),
     /// The response indicating that the connection has been accepted.
+    #[cfg(feature = "control_interface")]
     ControlInterfaceAccepted,
     /// The reason a connection closed was received.
     ConnectionClosedReason(String),
@@ -126,9 +128,82 @@ impl Response {
     /// ## Returns
     ///
     /// A new [Response] instance.
+    #[cfg(feature = "control_interface")]
     #[must_use]
     pub fn new(response: FromAnkaios) -> Self {
         Self::from(response)
+    }
+
+    /// Builds a [Response] from the transport-neutral `ank_base::Response` payload. Shared by
+    /// every [`Connection`](crate::components::connection::Connection) implementation, since the
+    /// payload itself carries no envelope-specific (control interface / gRPC) concepts.
+    ///
+    /// ## Arguments
+    ///
+    /// * `response` - The `ank_base::Response` to create the [Response] from.
+    ///
+    /// ## Returns
+    ///
+    /// A new [Response] instance.
+    pub(crate) fn from_ank_base(response: AnkaiosResponse) -> Self {
+        Self {
+            content: match response
+                .response_content
+                .unwrap_or(AnkaiosResponseContent::Error(Error {
+                    message: String::from("Response content is None."),
+                })) {
+                AnkaiosResponseContent::Error(err) => ResponseType::Error(err.message),
+                AnkaiosResponseContent::CompleteStateResponse(complete_state_response) => {
+                    if complete_state_response.altered_fields.is_some() {
+                        ResponseType::EventResponse(Box::new(EventEntry::from(
+                            *complete_state_response,
+                        )))
+                    } else {
+                        ResponseType::CompleteState(Box::new(CompleteState::new_from_proto(
+                            complete_state_response
+                                .complete_state
+                                .expect("Complete State response must contain Complete State."),
+                        )))
+                    }
+                }
+                AnkaiosResponseContent::UpdateStateSuccess(update_state_success) => {
+                    ResponseType::UpdateStateSuccess(Box::new(UpdateStateSuccess::new_from_proto(
+                        update_state_success,
+                    )))
+                }
+                AnkaiosResponseContent::LogsRequestAccepted(logs_request_accepted) => {
+                    ResponseType::LogsRequestAccepted(
+                        logs_request_accepted
+                            .workload_names
+                            .into_iter()
+                            .map(WorkloadInstanceName::from)
+                            .collect(),
+                    )
+                }
+                AnkaiosResponseContent::LogsCancelAccepted(_) => ResponseType::LogsCancelAccepted,
+                AnkaiosResponseContent::LogEntriesResponse(log_entries_response) => {
+                    let log_entries = log_entries_response
+                        .log_entries
+                        .into_iter()
+                        .map(LogEntry::from)
+                        .collect();
+
+                    ResponseType::LogEntriesResponse(log_entries)
+                }
+                AnkaiosResponseContent::LogsStopResponse(logs_stop_response) => {
+                    let instance_name = logs_stop_response
+                        .workload_name
+                        .map(WorkloadInstanceName::from)
+                        .unwrap_or_unreachable();
+
+                    ResponseType::LogsStopResponse(instance_name)
+                }
+                AnkaiosResponseContent::EventsCancelAccepted(_) => {
+                    ResponseType::EventsCancelAccepted
+                }
+            },
+            id: response.request_id,
+        }
     }
 
     /// Returns the request ID of the response.
@@ -153,86 +228,25 @@ impl Response {
     }
 }
 
+#[cfg(feature = "control_interface")]
 impl From<FromAnkaios> for Response {
     fn from(response: FromAnkaios) -> Self {
-        if let Some(response_enum) = response.from_ankaios_enum {
-            match response_enum {
-                FromAnkaiosEnum::Response(inner_response) => Self {
-                    content: match inner_response.response_content.unwrap_or(
-                        AnkaiosResponseContent::Error(Error {
-                            message: String::from("Response content is None."),
-                        }),
-                    ) {
-                        AnkaiosResponseContent::Error(err) => ResponseType::Error(err.message),
-                        AnkaiosResponseContent::CompleteStateResponse(complete_state_response) => {
-                            if complete_state_response.altered_fields.is_some() {
-                                ResponseType::EventResponse(Box::new(EventEntry::from(
-                                    *complete_state_response,
-                                )))
-                            } else {
-                                ResponseType::CompleteState(Box::new(
-                                    CompleteState::new_from_proto(
-                                        complete_state_response.complete_state.expect(
-                                            "Complete State response must contain Complete State.",
-                                        ),
-                                    ),
-                                ))
-                            }
-                        }
-                        AnkaiosResponseContent::UpdateStateSuccess(update_state_success) => {
-                            ResponseType::UpdateStateSuccess(Box::new(
-                                UpdateStateSuccess::new_from_proto(update_state_success),
-                            ))
-                        }
-                        AnkaiosResponseContent::LogsRequestAccepted(logs_request_accepted) => {
-                            ResponseType::LogsRequestAccepted(
-                                logs_request_accepted
-                                    .workload_names
-                                    .into_iter()
-                                    .map(WorkloadInstanceName::from)
-                                    .collect(),
-                            )
-                        }
-                        AnkaiosResponseContent::LogsCancelAccepted(_) => {
-                            ResponseType::LogsCancelAccepted
-                        }
-                        AnkaiosResponseContent::LogEntriesResponse(log_entries_response) => {
-                            let log_entries = log_entries_response
-                                .log_entries
-                                .into_iter()
-                                .map(LogEntry::from)
-                                .collect();
-
-                            ResponseType::LogEntriesResponse(log_entries)
-                        }
-                        AnkaiosResponseContent::LogsStopResponse(logs_stop_response) => {
-                            let instance_name = logs_stop_response
-                                .workload_name
-                                .map(WorkloadInstanceName::from)
-                                .unwrap_or_unreachable();
-
-                            ResponseType::LogsStopResponse(instance_name)
-                        }
-                        AnkaiosResponseContent::EventsCancelAccepted(_) => {
-                            ResponseType::EventsCancelAccepted
-                        }
-                    },
-                    id: inner_response.request_id,
-                },
-                FromAnkaiosEnum::ControlInterfaceAccepted(_) => Self {
-                    content: ResponseType::ControlInterfaceAccepted,
-                    id: String::default(),
-                },
-                FromAnkaiosEnum::ConnectionClosed(connection_closed) => Self {
-                    content: ResponseType::ConnectionClosedReason(connection_closed.reason),
-                    id: String::default(),
-                },
+        match response.from_ankaios_enum {
+            Some(FromAnkaiosEnum::Response(inner_response)) => {
+                Response::from_ank_base(*inner_response)
             }
-        } else {
-            Self {
+            Some(FromAnkaiosEnum::ControlInterfaceAccepted(_)) => Self {
+                content: ResponseType::ControlInterfaceAccepted,
+                id: String::default(),
+            },
+            Some(FromAnkaiosEnum::ConnectionClosed(connection_closed)) => Self {
+                content: ResponseType::ConnectionClosedReason(connection_closed.reason),
+                id: String::default(),
+            },
+            None => Self {
                 content: ResponseType::Error(String::from("Response is empty.")),
                 id: String::default(),
-            }
+            },
         }
     }
 }
@@ -317,6 +331,7 @@ impl UpdateStateSuccess {
 //////////////////////////////////////////////////////////////////////////////
 
 #[cfg(test)]
+#[cfg(feature = "control_interface")]
 pub fn generate_test_control_interface_accepted_response() -> Response {
     Response {
         content: ResponseType::ControlInterfaceAccepted,
@@ -325,43 +340,46 @@ pub fn generate_test_control_interface_accepted_response() -> Response {
 }
 
 #[cfg(test)]
+pub(crate) fn generate_test_ank_base_update_state_success(req_id: String) -> AnkaiosResponse {
+    AnkaiosResponse {
+        request_id: req_id,
+        response_content: Some(AnkaiosResponseContent::UpdateStateSuccess(
+            AnkaiosUpdateStateSuccess {
+                added_workloads: vec!["workload_test.1234.agent_Test".to_owned()],
+                deleted_workloads: Vec::default(),
+            },
+        )),
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "control_interface")]
 pub fn generate_test_proto_update_state_success(req_id: String) -> FromAnkaios {
     FromAnkaios {
         from_ankaios_enum: Some(FromAnkaiosEnum::Response(Box::new(
-            ankaios_api::ank_base::Response {
-                request_id: req_id,
-                response_content: Some(AnkaiosResponseContent::UpdateStateSuccess(
-                    AnkaiosUpdateStateSuccess {
-                        added_workloads: vec!["workload_test.1234.agent_Test".to_owned()],
-                        deleted_workloads: Vec::default(),
-                    },
-                )),
-            },
+            generate_test_ank_base_update_state_success(req_id),
         ))),
     }
 }
 
 #[cfg(test)]
 pub fn generate_test_response_update_state_success(req_id: String) -> Response {
-    Response::new(generate_test_proto_update_state_success(req_id))
+    Response::from_ank_base(generate_test_ank_base_update_state_success(req_id))
 }
 
 #[cfg(test)]
+#[cfg(feature = "control_interface")]
 pub fn get_test_proto_from_ankaios_log_entries_response(
     request_id: String,
     log_entries_response: ankaios_api::ank_base::LogEntriesResponse,
 ) -> FromAnkaios {
     FromAnkaios {
-        from_ankaios_enum: Some(
-            ankaios_api::control_api::from_ankaios::FromAnkaiosEnum::Response(Box::new(
-                ankaios_api::ank_base::Response {
-                    request_id,
-                    response_content: Some(AnkaiosResponseContent::LogEntriesResponse(
-                        log_entries_response,
-                    )),
-                },
+        from_ankaios_enum: Some(FromAnkaiosEnum::Response(Box::new(AnkaiosResponse {
+            request_id,
+            response_content: Some(AnkaiosResponseContent::LogEntriesResponse(
+                log_entries_response,
             )),
-        ),
+        }))),
     }
 }
 
@@ -390,6 +408,7 @@ pub fn generate_test_proto_log_entries_response() -> ankaios_api::ank_base::LogE
 }
 
 #[cfg(test)]
+#[cfg(feature = "control_interface")]
 pub fn generate_test_logs_stop_response(
     request_id: String,
     workload_name: WorkloadInstanceName,
@@ -401,55 +420,50 @@ pub fn generate_test_logs_stop_response(
 }
 
 #[cfg(test)]
+#[cfg(feature = "control_interface")]
 pub fn generate_test_response_event_entry(request_id: String) -> Response {
     let config_map = super::complete_state::generate_test_configs_proto();
     Response::new(FromAnkaios {
-        from_ankaios_enum: Some(
-            ankaios_api::control_api::from_ankaios::FromAnkaiosEnum::Response(Box::new(
-                ankaios_api::ank_base::Response {
-                    request_id,
-                    response_content: Some(AnkaiosResponseContent::CompleteStateResponse(
-                        Box::new(ankaios_api::ank_base::CompleteStateResponse {
-                            complete_state: Some(ankaios_api::ank_base::CompleteState {
-                                desired_state: Some(ankaios_api::ank_base::State {
-                                    api_version: "v1".to_owned(),
-                                    workloads: Some(ankaios_api::ank_base::WorkloadMap::default()),
-                                    configs: Some(config_map),
-                                }),
-                                workload_states: None,
-                                agents: None,
-                            }),
-                            altered_fields: Some(ankaios_api::ank_base::AlteredFields {
-                                added_fields: vec![
-                                    "desiredState.configs.config2".to_owned(),
-                                    "desiredState.configs.config3".to_owned(),
-                                ],
-                                updated_fields: vec!["desiredState.configs.config1".to_owned()],
-                                removed_fields: vec!["desiredState.configs.config4".to_owned()],
-                            }),
+        from_ankaios_enum: Some(FromAnkaiosEnum::Response(Box::new(AnkaiosResponse {
+            request_id,
+            response_content: Some(AnkaiosResponseContent::CompleteStateResponse(Box::new(
+                ankaios_api::ank_base::CompleteStateResponse {
+                    complete_state: Some(ankaios_api::ank_base::CompleteState {
+                        desired_state: Some(ankaios_api::ank_base::State {
+                            api_version: "v1".to_owned(),
+                            workloads: Some(ankaios_api::ank_base::WorkloadMap::default()),
+                            configs: Some(config_map),
                         }),
-                    )),
+                        workload_states: None,
+                        agents: None,
+                    }),
+                    altered_fields: Some(ankaios_api::ank_base::AlteredFields {
+                        added_fields: vec![
+                            "desiredState.configs.config2".to_owned(),
+                            "desiredState.configs.config3".to_owned(),
+                        ],
+                        updated_fields: vec!["desiredState.configs.config1".to_owned()],
+                        removed_fields: vec!["desiredState.configs.config4".to_owned()],
+                    }),
                 },
-            )),
-        ),
+            ))),
+        }))),
     })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Response, ResponseType, UpdateStateSuccess};
+    use super::{
+        AnkaiosResponse, AnkaiosResponseContent, Response, ResponseType, UpdateStateSuccess,
+    };
     use crate::components::complete_state::generate_test_configs_proto;
-    use crate::components::response::{
-        generate_test_proto_log_entries_response, generate_test_response_event_entry,
-        get_test_proto_from_ankaios_log_entries_response,
-    };
+    use crate::components::response::generate_test_proto_log_entries_response;
     use crate::{EventEntry, ankaios_api};
-    use ankaios_api::ank_base::{
-        Response as AnkaiosResponse, UpdateStateSuccess as AnkaiosUpdateStateSuccess,
-        response::ResponseContent as AnkaiosResponseContent,
-    };
-    use ankaios_api::control_api::{FromAnkaios, from_ankaios};
+    use ankaios_api::ank_base::UpdateStateSuccess as AnkaiosUpdateStateSuccess;
     use std::collections::HashMap;
+
+    #[cfg(feature = "control_interface")]
+    use ankaios_api::control_api::{FromAnkaios, from_ankaios};
 
     #[test]
     fn utest_response_type() {
@@ -471,15 +485,11 @@ mod tests {
 
     #[test]
     fn utest_response_error() {
-        let response = Response::new(FromAnkaios {
-            from_ankaios_enum: Some(from_ankaios::FromAnkaiosEnum::Response(Box::new(
-                AnkaiosResponse {
-                    request_id: String::from("123"),
-                    response_content: Some(AnkaiosResponseContent::Error(
-                        ankaios_api::ank_base::Error::default(),
-                    )),
-                },
-            ))),
+        let response = Response::from_ank_base(AnkaiosResponse {
+            request_id: String::from("123"),
+            response_content: Some(AnkaiosResponseContent::Error(
+                ankaios_api::ank_base::Error::default(),
+            )),
         });
         assert_eq!(response.get_request_id(), "123".to_owned());
         assert_eq!(
@@ -490,22 +500,18 @@ mod tests {
 
     #[test]
     fn utest_response_complete_state() {
-        let response = Response::new(FromAnkaios {
-            from_ankaios_enum: Some(from_ankaios::FromAnkaiosEnum::Response(Box::new(
-                AnkaiosResponse {
-                    request_id: String::from("123"),
-                    response_content: Some(AnkaiosResponseContent::CompleteStateResponse(
-                        Box::new(ankaios_api::ank_base::CompleteStateResponse {
-                            complete_state: Some(ankaios_api::ank_base::CompleteState {
-                                desired_state: Some(ankaios_api::ank_base::State {
-                                    api_version: "v1".to_owned(),
-                                    ..Default::default()
-                                }),
-                                ..Default::default()
-                            }),
-                            altered_fields: None,
+        let response = Response::from_ank_base(AnkaiosResponse {
+            request_id: String::from("123"),
+            response_content: Some(AnkaiosResponseContent::CompleteStateResponse(Box::new(
+                ankaios_api::ank_base::CompleteStateResponse {
+                    complete_state: Some(ankaios_api::ank_base::CompleteState {
+                        desired_state: Some(ankaios_api::ank_base::State {
+                            api_version: "v1".to_owned(),
+                            ..Default::default()
                         }),
-                    )),
+                        ..Default::default()
+                    }),
+                    altered_fields: None,
                 },
             ))),
         });
@@ -518,15 +524,11 @@ mod tests {
 
     #[test]
     fn utest_response_update_state_success() {
-        let response = Response::new(FromAnkaios {
-            from_ankaios_enum: Some(from_ankaios::FromAnkaiosEnum::Response(Box::new(
-                AnkaiosResponse {
-                    request_id: String::from("123"),
-                    response_content: Some(AnkaiosResponseContent::UpdateStateSuccess(
-                        ankaios_api::ank_base::UpdateStateSuccess::default(),
-                    )),
-                },
-            ))),
+        let response = Response::from_ank_base(AnkaiosResponse {
+            request_id: String::from("123"),
+            response_content: Some(AnkaiosResponseContent::UpdateStateSuccess(
+                ankaios_api::ank_base::UpdateStateSuccess::default(),
+            )),
         });
         assert_eq!(response.get_request_id(), "123".to_owned());
         assert_eq!(
@@ -535,6 +537,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "control_interface")]
     #[test]
     fn utest_response_control_interface_accepted() {
         let response = Response::new(FromAnkaios {
@@ -549,6 +552,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "control_interface")]
     #[test]
     fn utest_response_connection_closed() {
         let response = Response::new(FromAnkaios {
@@ -563,6 +567,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "control_interface")]
     #[test]
     fn utest_response_empty() {
         let response = Response::new(FromAnkaios {
@@ -645,17 +650,13 @@ mod tests {
             },
         ];
 
-        let response = Response::new(FromAnkaios {
-            from_ankaios_enum: Some(from_ankaios::FromAnkaiosEnum::Response(Box::new(
-                AnkaiosResponse {
-                    request_id: String::from("123"),
-                    response_content: Some(AnkaiosResponseContent::LogsRequestAccepted(
-                        ankaios_api::ank_base::LogsRequestAccepted {
-                            workload_names: workload_names.clone(),
-                        },
-                    )),
+        let response = Response::from_ank_base(AnkaiosResponse {
+            request_id: String::from("123"),
+            response_content: Some(AnkaiosResponseContent::LogsRequestAccepted(
+                ankaios_api::ank_base::LogsRequestAccepted {
+                    workload_names: workload_names.clone(),
                 },
-            ))),
+            )),
         });
 
         assert_eq!(response.get_request_id(), "123".to_owned());
@@ -672,15 +673,11 @@ mod tests {
 
     #[test]
     fn utest_response_logs_cancel_accepted() {
-        let response = Response::new(FromAnkaios {
-            from_ankaios_enum: Some(from_ankaios::FromAnkaiosEnum::Response(Box::new(
-                AnkaiosResponse {
-                    request_id: String::from("123"),
-                    response_content: Some(AnkaiosResponseContent::LogsCancelAccepted(
-                        ankaios_api::ank_base::LogsCancelAccepted {},
-                    )),
-                },
-            ))),
+        let response = Response::from_ank_base(AnkaiosResponse {
+            request_id: String::from("123"),
+            response_content: Some(AnkaiosResponseContent::LogsCancelAccepted(
+                ankaios_api::ank_base::LogsCancelAccepted {},
+            )),
         });
         assert_eq!(response.get_request_id(), "123".to_owned());
         assert_eq!(response.get_content(), ResponseType::LogsCancelAccepted);
@@ -690,10 +687,12 @@ mod tests {
     fn utest_response_log_entries_response() {
         let log_entries_response = generate_test_proto_log_entries_response();
         let log_entries = log_entries_response.log_entries.clone();
-        let response = Response::new(get_test_proto_from_ankaios_log_entries_response(
-            "123".to_owned(),
-            log_entries_response.clone(),
-        ));
+        let response = Response::from_ank_base(AnkaiosResponse {
+            request_id: "123".to_owned(),
+            response_content: Some(AnkaiosResponseContent::LogEntriesResponse(
+                log_entries_response,
+            )),
+        });
         assert_eq!(response.get_request_id(), "123".to_owned());
         assert_eq!(
             response.get_content(),
@@ -714,22 +713,14 @@ mod tests {
             id: "id_a".to_owned(),
         };
 
-        let from_ankaios_response = FromAnkaios {
-            from_ankaios_enum: Some(
-                ankaios_api::control_api::from_ankaios::FromAnkaiosEnum::Response(Box::new(
-                    ankaios_api::ank_base::Response {
-                        request_id: "123".to_owned(),
-                        response_content: Some(AnkaiosResponseContent::LogsStopResponse(
-                            ankaios_api::ank_base::LogsStopResponse {
-                                workload_name: Some(expected_instance_name.clone()),
-                            },
-                        )),
-                    },
-                )),
-            ),
-        };
-
-        let response = Response::new(from_ankaios_response);
+        let response = Response::from_ank_base(AnkaiosResponse {
+            request_id: "123".to_owned(),
+            response_content: Some(AnkaiosResponseContent::LogsStopResponse(
+                ankaios_api::ank_base::LogsStopResponse {
+                    workload_name: Some(expected_instance_name.clone()),
+                },
+            )),
+        });
 
         assert_eq!(response.get_request_id(), "123".to_owned());
         assert_eq!(
@@ -740,45 +731,46 @@ mod tests {
 
     #[test]
     fn utest_response_event_entry() {
-        let response = generate_test_response_event_entry("123".to_owned());
+        let complete_state_response = ankaios_api::ank_base::CompleteStateResponse {
+            complete_state: Some(ankaios_api::ank_base::CompleteState {
+                desired_state: Some(ankaios_api::ank_base::State {
+                    api_version: "v1".to_owned(),
+                    workloads: Some(ankaios_api::ank_base::WorkloadMap::default()),
+                    configs: Some(generate_test_configs_proto()),
+                }),
+                workload_states: None,
+                agents: None,
+            }),
+            altered_fields: Some(ankaios_api::ank_base::AlteredFields {
+                added_fields: vec![
+                    "desiredState.configs.config2".to_owned(),
+                    "desiredState.configs.config3".to_owned(),
+                ],
+                updated_fields: vec!["desiredState.configs.config1".to_owned()],
+                removed_fields: vec!["desiredState.configs.config4".to_owned()],
+            }),
+        };
+
+        let response = Response::from_ank_base(AnkaiosResponse {
+            request_id: "123".to_owned(),
+            response_content: Some(AnkaiosResponseContent::CompleteStateResponse(Box::new(
+                complete_state_response.clone(),
+            ))),
+        });
         assert_eq!(response.get_request_id(), "123".to_owned());
         assert_eq!(
             response.get_content(),
-            ResponseType::EventResponse(Box::new(EventEntry::from(
-                ankaios_api::ank_base::CompleteStateResponse {
-                    complete_state: Some(ankaios_api::ank_base::CompleteState {
-                        desired_state: Some(ankaios_api::ank_base::State {
-                            api_version: "v1".to_owned(),
-                            workloads: Some(ankaios_api::ank_base::WorkloadMap::default()),
-                            configs: Some(generate_test_configs_proto()),
-                        }),
-                        workload_states: None,
-                        agents: None,
-                    }),
-                    altered_fields: Some(ankaios_api::ank_base::AlteredFields {
-                        added_fields: vec![
-                            "desiredState.configs.config2".to_owned(),
-                            "desiredState.configs.config3".to_owned()
-                        ],
-                        updated_fields: vec!["desiredState.configs.config1".to_owned()],
-                        removed_fields: vec!["desiredState.configs.config4".to_owned()],
-                    }),
-                }
-            )))
+            ResponseType::EventResponse(Box::new(EventEntry::from(complete_state_response)))
         );
     }
 
     #[test]
     fn utest_response_events_cancel_accepted() {
-        let response = Response::new(FromAnkaios {
-            from_ankaios_enum: Some(from_ankaios::FromAnkaiosEnum::Response(Box::new(
-                AnkaiosResponse {
-                    request_id: String::from("123"),
-                    response_content: Some(AnkaiosResponseContent::EventsCancelAccepted(
-                        ankaios_api::ank_base::EventsCancelAccepted {},
-                    )),
-                },
-            ))),
+        let response = Response::from_ank_base(AnkaiosResponse {
+            request_id: String::from("123"),
+            response_content: Some(AnkaiosResponseContent::EventsCancelAccepted(
+                ankaios_api::ank_base::EventsCancelAccepted {},
+            )),
         });
         assert_eq!(response.get_request_id(), "123".to_owned());
         assert_eq!(response.get_content(), ResponseType::EventsCancelAccepted);

--- a/src/components/response.rs
+++ b/src/components/response.rs
@@ -134,18 +134,33 @@ impl Response {
         Self::from(response)
     }
 
-    /// Builds a [Response] from the transport-neutral `ank_base::Response` payload. Shared by
-    /// every [`Connection`](crate::components::connection::Connection) implementation, since the
-    /// payload itself carries no envelope-specific (control interface / gRPC) concepts.
-    ///
-    /// ## Arguments
-    ///
-    /// * `response` - The `ank_base::Response` to create the [Response] from.
+    /// Returns the request ID of the response.
     ///
     /// ## Returns
     ///
-    /// A new [Response] instance.
-    pub(crate) fn from_ank_base(response: AnkaiosResponse) -> Self {
+    /// A [String] containing the request ID of the response.
+    #[must_use]
+    pub fn get_request_id(&self) -> String {
+        self.id.clone()
+    }
+
+    /// Returns the content of the response.
+    ///
+    /// ## Returns
+    ///
+    /// A [`ResponseType`] containing the content of the response.
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn get_content(&self) -> ResponseType {
+        self.content.clone()
+    }
+}
+
+/// Builds a [Response] from the transport-neutral `ank_base::Response` payload. Shared by
+/// every [`Connection`](crate::components::connection::Connection) implementation, since the
+/// payload itself carries no envelope-specific concepts.
+impl From<AnkaiosResponse> for Response {
+    fn from(response: AnkaiosResponse) -> Self {
         Self {
             content: match response
                 .response_content
@@ -205,36 +220,13 @@ impl Response {
             id: response.request_id,
         }
     }
-
-    /// Returns the request ID of the response.
-    ///
-    /// ## Returns
-    ///
-    /// A [String] containing the request ID of the response.
-    #[must_use]
-    pub fn get_request_id(&self) -> String {
-        self.id.clone()
-    }
-
-    /// Returns the content of the response.
-    ///
-    /// ## Returns
-    ///
-    /// A [`ResponseType`] containing the content of the response.
-    #[must_use]
-    #[allow(dead_code)]
-    pub fn get_content(&self) -> ResponseType {
-        self.content.clone()
-    }
 }
 
 #[cfg(feature = "control_interface")]
 impl From<FromAnkaios> for Response {
     fn from(response: FromAnkaios) -> Self {
         match response.from_ankaios_enum {
-            Some(FromAnkaiosEnum::Response(inner_response)) => {
-                Response::from_ank_base(*inner_response)
-            }
+            Some(FromAnkaiosEnum::Response(inner_response)) => Response::from(*inner_response),
             Some(FromAnkaiosEnum::ControlInterfaceAccepted(_)) => Self {
                 content: ResponseType::ControlInterfaceAccepted,
                 id: String::default(),
@@ -364,7 +356,7 @@ pub fn generate_test_proto_update_state_success(req_id: String) -> FromAnkaios {
 
 #[cfg(test)]
 pub fn generate_test_response_update_state_success(req_id: String) -> Response {
-    Response::from_ank_base(generate_test_ank_base_update_state_success(req_id))
+    Response::from(generate_test_ank_base_update_state_success(req_id))
 }
 
 #[cfg(test)]
@@ -485,7 +477,7 @@ mod tests {
 
     #[test]
     fn utest_response_error() {
-        let response = Response::from_ank_base(AnkaiosResponse {
+        let response = Response::from(AnkaiosResponse {
             request_id: String::from("123"),
             response_content: Some(AnkaiosResponseContent::Error(
                 ankaios_api::ank_base::Error::default(),
@@ -500,7 +492,7 @@ mod tests {
 
     #[test]
     fn utest_response_complete_state() {
-        let response = Response::from_ank_base(AnkaiosResponse {
+        let response = Response::from(AnkaiosResponse {
             request_id: String::from("123"),
             response_content: Some(AnkaiosResponseContent::CompleteStateResponse(Box::new(
                 ankaios_api::ank_base::CompleteStateResponse {
@@ -524,7 +516,7 @@ mod tests {
 
     #[test]
     fn utest_response_update_state_success() {
-        let response = Response::from_ank_base(AnkaiosResponse {
+        let response = Response::from(AnkaiosResponse {
             request_id: String::from("123"),
             response_content: Some(AnkaiosResponseContent::UpdateStateSuccess(
                 ankaios_api::ank_base::UpdateStateSuccess::default(),
@@ -650,7 +642,7 @@ mod tests {
             },
         ];
 
-        let response = Response::from_ank_base(AnkaiosResponse {
+        let response = Response::from(AnkaiosResponse {
             request_id: String::from("123"),
             response_content: Some(AnkaiosResponseContent::LogsRequestAccepted(
                 ankaios_api::ank_base::LogsRequestAccepted {
@@ -673,7 +665,7 @@ mod tests {
 
     #[test]
     fn utest_response_logs_cancel_accepted() {
-        let response = Response::from_ank_base(AnkaiosResponse {
+        let response = Response::from(AnkaiosResponse {
             request_id: String::from("123"),
             response_content: Some(AnkaiosResponseContent::LogsCancelAccepted(
                 ankaios_api::ank_base::LogsCancelAccepted {},
@@ -687,7 +679,7 @@ mod tests {
     fn utest_response_log_entries_response() {
         let log_entries_response = generate_test_proto_log_entries_response();
         let log_entries = log_entries_response.log_entries.clone();
-        let response = Response::from_ank_base(AnkaiosResponse {
+        let response = Response::from(AnkaiosResponse {
             request_id: "123".to_owned(),
             response_content: Some(AnkaiosResponseContent::LogEntriesResponse(
                 log_entries_response,
@@ -713,7 +705,7 @@ mod tests {
             id: "id_a".to_owned(),
         };
 
-        let response = Response::from_ank_base(AnkaiosResponse {
+        let response = Response::from(AnkaiosResponse {
             request_id: "123".to_owned(),
             response_content: Some(AnkaiosResponseContent::LogsStopResponse(
                 ankaios_api::ank_base::LogsStopResponse {
@@ -751,7 +743,7 @@ mod tests {
             }),
         };
 
-        let response = Response::from_ank_base(AnkaiosResponse {
+        let response = Response::from(AnkaiosResponse {
             request_id: "123".to_owned(),
             response_content: Some(AnkaiosResponseContent::CompleteStateResponse(Box::new(
                 complete_state_response.clone(),
@@ -766,7 +758,7 @@ mod tests {
 
     #[test]
     fn utest_response_events_cancel_accepted() {
-        let response = Response::from_ank_base(AnkaiosResponse {
+        let response = Response::from(AnkaiosResponse {
             request_id: String::from("123"),
             response_content: Some(AnkaiosResponseContent::EventsCancelAccepted(
                 ankaios_api::ank_base::EventsCancelAccepted {},

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -52,9 +52,9 @@ pub enum AnkaiosError {
     /// Represents an error that occurs when the response is invalid.
     #[error("Response error: {0}")]
     ResponseError(String),
-    /// Represents an error related to the connection with the control interface.
-    #[error("Control interface error: {0}")]
-    ControlInterfaceError(String),
+    /// Represents an error related to the connection.
+    #[error("Connection error: {0}")]
+    ConnectionError(String),
     /// Represents an error returned by the server in response to a distinct request.
     /// e.g. due to insufficient reading rights by the requester.
     #[error("Ankaios response error: {0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,8 @@
 //! After setup, you can use the Ankaios SDK to configure and run workloads
 //! and request the state of the Ankaios system and the connected agents.
 //!
+//! ### Connecting over The Control Interface
+//!
 //! The following example assumes that the code is running in a workload managed by
 //! Ankaios with configured control interface access. This can also be tested from the
 //! examples folder by running `./run_example.sh hello_ankaios`.
@@ -191,7 +193,44 @@
 //!     }
 //! }
 //! ```
-//!
+//! 
+//! ### Connecting over The Command Interface
+//! 
+//! To connect to an Ankaios server directly from outside a workload (e.g. from
+//! a CI job or a management tool), use the command interface instead, which relies on
+//! a gRPC connection directly to the Ankaios agent:
+//! 
+//! ```rust
+//! use ankaios_sdk::{Ankaios, GrpcConfig};
+//! use tokio::time::Duration;
+//! 
+//! #[tokio::main]
+//! async fn main() {
+//!     // Setup the gRPC connection
+//!     let grpc_config = GrpcConfig::insecure(server_url); // or GrpcConfig::mtls
+//!     // Create a new Ankaios object.
+//! 
+//!     // The connection to the command interface is automatically done at this step.
+//!     let mut ank = Ankaios::builder().command_interface(grpc_config).connect().await.expect("Failed to initialize");
+//! 
+//!     ...
+//! }
+//! ```
+//! 
+//! This requires the command interface feature to be enabled:
+//! 
+//! ```toml
+//! ankaios_sdk = { ..., default-features = false, features = ["command_interface"] }
+//! ```
+//! 
+//! > **_NOTE:_**  The default feature is the control interface. Without disabling it,
+//! > both features will be available.
+//! 
+//! For mTLS-secured connections, also pass `ca_pem`, `crt_pem` and `key_pem`
+//! (the PEM-encoded CA certificate, client certificate and client key content).
+//! 
+//! ### Resources
+//! 
 //! For more details, please visit:
 //!
 //! * [Ankaios documentation](https://eclipse-ankaios.github.io/ankaios/latest/)
@@ -207,10 +246,10 @@
 //! Ankaios Rust SDK is licensed using the Apache License Version 2.0.
 //!
 
-#[cfg(not(any(feature = "control_interface", feature = "grpc_server_interface")))]
+#[cfg(not(any(feature = "control_interface", feature = "command_interface")))]
 compile_error!(
     "ankaios_sdk requires at least one connection feature to be enabled: \
-     `control_interface` and/or `grpc_server_interface`."
+     `control_interface` and/or `command_interface`."
 );
 
 mod ankaios_api;
@@ -222,10 +261,10 @@ pub use errors::AnkaiosError;
 
 mod components;
 
+#[cfg(feature = "command_interface")]
+pub use components::connection::command_interface::GrpcConfig;
 #[cfg(feature = "control_interface")]
 pub use components::connection::control_interface::ControlInterfaceState;
-#[cfg(feature = "grpc_server_interface")]
-pub use components::connection::grpc_interface::GrpcConfig;
 
 pub use components::complete_state::{AgentAttributes, CompleteState};
 pub use components::event_types::{EventEntry, EventsCampaignResponse};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@
 //! async fn main() {
 //!     // Create a new Ankaios object.
 //!     // The connection to the control interface is automatically done at this step.
-//!     let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
+//!     let mut ank = Ankaios::builder().control_interface().connect().await.expect("Failed to initialize");
 //!
 //!     // Create a new workload
 //!     let workload = Workload::builder()
@@ -240,4 +240,4 @@ pub use components::workload_state_mod::{
 };
 
 mod ankaios;
-pub use ankaios::Ankaios;
+pub use ankaios::{Ankaios, AnkaiosBuilder};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@
 //! async fn main() {
 //!     // Create a new Ankaios object.
 //!     // The connection to the control interface is automatically done at this step.
-//!     let mut ank = Ankaios::new().await.expect("Failed to initialize");
+//!     let mut ank = Ankaios::new_with_ci().await.expect("Failed to initialize");
 //!
 //!     // Create a new workload
 //!     let workload = Workload::builder()
@@ -207,6 +207,12 @@
 //! Ankaios Rust SDK is licensed using the Apache License Version 2.0.
 //!
 
+#[cfg(not(any(feature = "control_interface", feature = "grpc_server_interface")))]
+compile_error!(
+    "ankaios_sdk requires at least one connection feature to be enabled: \
+     `control_interface` and/or `grpc_server_interface`."
+);
+
 mod ankaios_api;
 mod docs;
 pub mod extensions;
@@ -216,8 +222,12 @@ pub use errors::AnkaiosError;
 
 mod components;
 
+#[cfg(feature = "control_interface")]
+pub use components::connection::control_interface::ControlInterfaceState;
+#[cfg(feature = "grpc_server_interface")]
+pub use components::connection::grpc_interface::GrpcConfig;
+
 pub use components::complete_state::{AgentAttributes, CompleteState};
-pub use components::control_interface::ControlInterfaceState;
 pub use components::event_types::{EventEntry, EventsCampaignResponse};
 pub use components::log_types::{LogCampaignResponse, LogEntry, LogResponse, LogsRequest};
 pub use components::manifest::Manifest;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,20 +200,20 @@
 //! a CI job or a management tool), use the command interface instead, which relies on
 //! a gRPC connection directly to the Ankaios agent:
 //! 
-//! ```rust
+//! ```rust,no_run
 //! use ankaios_sdk::{Ankaios, GrpcConfig};
-//! use tokio::time::Duration;
-//! 
+//!
 //! #[tokio::main]
 //! async fn main() {
 //!     // Setup the gRPC connection
+//!     let server_url = "http://127.0.0.1:25551";
 //!     let grpc_config = GrpcConfig::insecure(server_url); // or GrpcConfig::mtls
+//!
 //!     // Create a new Ankaios object.
-//! 
 //!     // The connection to the command interface is automatically done at this step.
 //!     let mut ank = Ankaios::builder().command_interface(grpc_config).connect().await.expect("Failed to initialize");
-//! 
-//!     ...
+//!
+//!     // From here on, the API is identical to the control interface example above.
 //! }
 //! ```
 //! 

--- a/tools/check_coverage.sh
+++ b/tools/check_coverage.sh
@@ -61,7 +61,7 @@ fi
 
 # Extract the last coverage line with the TOTAL stats
 echo "Running coverage analysis..."
-TOTAL_LINE=$(cargo llvm-cov 2>/dev/null | grep "TOTAL")
+TOTAL_LINE=$(cargo llvm-cov --all-features 2>/dev/null | grep "TOTAL")
 
 # Check if we got a coverage result
 if [[ -z "$TOTAL_LINE" ]]; then

--- a/tools/update_version.sh
+++ b/tools/update_version.sh
@@ -109,7 +109,7 @@ fi
 
 if [ -n "$ankaios_version" ]; then
     echo "Updating Ankaios version to $ankaios_version"
-    sed -i "s/const ANKAIOS_VERSION: &str = .*/const ANKAIOS_VERSION: \&str = \"$ankaios_version\";/" "$base_dir"/src/components/control_interface.rs
+    sed -i "s/const ANKAIOS_VERSION: &str = .*/const ANKAIOS_VERSION: \&str = \"$ankaios_version\";/" "$base_dir"/src/components/connection/mod.rs
 fi
 
 if [ -n "$api_version" ]; then


### PR DESCRIPTION
Issue: https://github.com/eclipse-ankaios/ank-sdk-rust/issues/35 https://github.com/eclipse-ankaios/ankaios/issues/764

The available Rust SDK can be used **only** inside of a workload, and it connects to Ankaios using the Control API through the mounted pipes of the workload.
This PR adds another connection type to the SDK, allowing it to connect directly to the Ankaios Server, from the outside, similarly to how the Ankaios CLI function. This allows users to run applications outside of workloads and still be able to fetch or modify the state of the cluster.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-contribute) have been handled
