### PR TITLE
Expose WorkloadSubStateEnum

### DIFF
--- a/src/components/workload_state_mod/workload_state_enums.rs
+++ b/src/components/workload_state_mod/workload_state_enums.rs
@@ -218,6 +218,7 @@ impl WorkloadSubStateEnum {
     /// ## Returns
     ///
     /// An [i32] value representing the [`WorkloadSubStateEnum`].
+    #[must_use]
     pub fn to_i32(self) -> i32 {
         match self {
             WorkloadSubStateEnum::AgentDisconnected => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,6 +226,7 @@ pub use components::response::{Response, UpdateStateSuccess};
 pub use components::workload_mod::{File, FileContent, Workload, WorkloadBuilder};
 pub use components::workload_state_mod::{
     WorkloadInstanceName, WorkloadState, WorkloadStateCollection, WorkloadStateEnum,
+    WorkloadSubStateEnum,
 };
 
 mod ankaios;


### PR DESCRIPTION
# Description

If a user needs to match the state and substate of a workload, it does not have access to the sub state enum. This PR fixes the issue.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](../CONTRIBUTING.md#how-to-contribute) have been handled
